### PR TITLE
Metadata and Spectra file are now optionals or can be generated both 

### DIFF
--- a/MainClass.cs
+++ b/MainClass.cs
@@ -98,7 +98,7 @@ namespace ThermoRawFileParser
             }
             catch (ArgumentNullException argumentNullException)
             {
-                if (help)
+                if(help)
                 {
                     ShowHelp(" usage is (use -option=value for the optional arguments):", null,
                         optionSet);

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -47,7 +47,7 @@ namespace ThermoRawFileParser
                     v => gzip = v != null
                 },
                 {
-                    "m|metadata=", "Write the metadata output file if this flag is specified (0 for JSON, 1 for .txt).",
+                    "m|metadata=", "Write the metadata output file if this flag is specified (0 for JSON, 1 for TXT).",
                     v => outputMetadataString = v 
                 },
                 {

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -14,9 +14,10 @@ namespace ThermoRawFileParser
             string rawFilePath = null;
             string outputDirectory = null;
             string outputFormatString = null;
-            var outputFormat = OutputFormat.Mgf;
+            var outputFormat = OutputFormat.NON;
             var gzip = false;
-            var outputMetadata = false;
+            string outputMetadataString = null; 
+            var outputMetadataFormat = MetadataFormat.NON;
             var includeProfileData = false;
             string collection = null;
             string msRun = null;
@@ -34,11 +35,11 @@ namespace ThermoRawFileParser
                     v => rawFilePath = v
                 },
                 {
-                    "o=|output=", "The metadata and mgf output directory.",
+                    "o=|output=", "The output directory.",
                     v => outputDirectory = v
                 },
                 {
-                    "f=|format=", "The output format (0 for MGF, 1 for MzMl)",
+                    "f=|format=", "The output format for the spectra (0 for MGF, 1 for MzMl)",
                     v => outputFormatString = v
                 },
                 {
@@ -46,8 +47,8 @@ namespace ThermoRawFileParser
                     v => gzip = v != null
                 },
                 {
-                    "m|metadata", "Write the metadata output file if this flag is specified (without value).",
-                    v => outputMetadata = v != null
+                    "m|metadata=", "Write the metadata output file if this flag is specified (0 for JSON, 1 for .txt).",
+                    v => outputMetadataString = v 
                 },
                 {
                     "p|profiledata",
@@ -74,16 +75,38 @@ namespace ThermoRawFileParser
             {
                 //parse the command line
                 var extra = optionSet.Parse(args);
+                
+                if(outputMetadataString == null && outputFormatString == null)
+                    throw new OptionException("The parameter -f or -m should be provided", "-f|--format , -m|--format");
 
-                var outPutFormatInt = int.Parse(outputFormatString);
-
-                if (Enum.IsDefined(typeof(OutputFormat), outPutFormatInt))
+                if (outputFormatString != null )
                 {
-                    outputFormat = (OutputFormat) outPutFormatInt;
+                    var outPutFormatInt = int.Parse(outputFormatString);
+              
+                    if (Enum.IsDefined(typeof(OutputFormat), outPutFormatInt))
+                        outputFormat = (OutputFormat) outPutFormatInt;
+                    else
+                        throw new OptionException("unknown output format", "-f, --format");
+                    
+                    if (Enum.IsDefined(typeof(OutputFormat), outPutFormatInt))
+                        outputFormat = (OutputFormat) outPutFormatInt;
+                    else
+                        throw new OptionException("unknown output format", "-f, --format");
                 }
-                else
+                
+                if (outputMetadataString != null)
                 {
-                    throw new OptionException("unknown output format", "-f, --format");
+                    var metadataInt = int.Parse(outputMetadataString);
+               
+                    if (Enum.IsDefined(typeof(MetadataFormat), metadataInt))
+                        outputMetadataFormat = (MetadataFormat) metadataInt;
+                    else
+                        throw new OptionException("unknown output format", "-m, --metadata");
+                   
+                    if (Enum.IsDefined(typeof(MetadataFormat), metadataInt))
+                        outputMetadataFormat = (MetadataFormat) metadataInt;
+                    else
+                        throw new OptionException("unknown output format", "-f, --metadata");
                 }
 
                 if (!extra.IsNullOrEmpty())
@@ -121,7 +144,7 @@ namespace ThermoRawFileParser
                 try
                 {
                     var parseInput = new ParseInput(rawFilePath, outputDirectory, outputFormat, gzip,
-                        outputMetadata,
+                        outputMetadataFormat,
                         includeProfileData, collection, msRun, subFolder);
                     RawFileParser.Parse(parseInput);
                 }

--- a/OutputFormat.cs
+++ b/OutputFormat.cs
@@ -2,6 +2,11 @@
 {
     public enum OutputFormat
     {
-        Mgf, Mzml
+        Mgf, Mzml , NON
+    }
+
+    public enum MetadataFormat
+    {
+        JSON, TXT , NON 
     }
 }

--- a/ParseInput.cs
+++ b/ParseInput.cs
@@ -27,7 +27,7 @@ namespace ThermoRawFileParser
         /// <summary>
         /// Output the metadata.
         /// </summary>
-        public bool OutputMetadata { get; }
+        public MetadataFormat OutputMetadata { get; }
 
         /// <summary>
         /// Exclude the MS2 spectra in profile mode.
@@ -61,7 +61,7 @@ namespace ThermoRawFileParser
         public string RawFileNameWithoutExtension { get; }
 
         public ParseInput(string rawFilePath, string outputDirectory, OutputFormat outputFormat, bool gzip,
-            bool outputMetadata, bool excludeProfileData, string collection, string msRun, string subFolder)
+            MetadataFormat outputMetadata, bool excludeProfileData, string collection, string msRun, string subFolder)
         {
             RawFilePath = rawFilePath;
             var splittedPath = RawFilePath.Split('/');

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config")]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ RawFileReader reading tool. Copyright © 2016 by Thermo Fisher Scientific, Inc. 
 ```
 mono ThermoRawFileParser.exe -i=/home/user/data_input/raw_file.raw -o=/home/niels/data_input/output/ -f=0 -g -m -c=PXD00001
 ```
-The optional parameters only work in the -option=value format. The metadata file is only created when the `-m` is specified. For the MGF format, `-p` flag is used to exclude MS2 profile mode data (the MGF files can get big when the MS2 spectra were acquired in profile mode). 
+The optional parameters only work in the -option=value format. The too can generate the metadata of the file `-m` and the spectra file `-f` or both. For the MGF format, `-p` flag is used to exclude MS2 profile mode data (the MGF files can get big when the MS2 spectra were acquired in profile mode). 
 
 ```
 ThermoRawFileParser.exe usage is (use -option=value for the optional arguments):
@@ -24,7 +24,7 @@ ThermoRawFileParser.exe usage is (use -option=value for the optional arguments):
   -g, --gzip                 GZip the output file if this flag is specified (
                                without value).
   -m, --metadata             Write the metadata output file if this flag is
-                               specified (without value).
+                               specified (0 for JSON, 1 for TXT).
   -p, --profiledata          Exclude MS2 profile data if this flag is specified
                                (without value). Only for MGF format!
   -c, --collection[=VALUE]   The optional collection identifier (PXD identifier
@@ -59,4 +59,3 @@ or with the bash script (`ThermoRawFileParser.sh`):
 ```
 docker run -v /home/user/raw:/data_input -i -t --user biodocker thermorawparser /bin/bash /home/biodocker/bin/ThermoRawFileParser.sh -i=/data_input/raw_file.raw -o=/data_input/output/ -f=0 -g -m -c=PXD00001
 ```
-

--- a/RawFileParser.cs
+++ b/RawFileParser.cs
@@ -71,27 +71,32 @@ namespace ThermoRawFileParser
                 var firstScanNumber = rawFile.RunHeaderEx.FirstSpectrum;
                 var lastScanNumber = rawFile.RunHeaderEx.LastSpectrum;
 
-                if (parseInput.OutputMetadata)
+                if (parseInput.OutputMetadata != MetadataFormat.NON)
                 {
-                    var metadataWriter = new MetadataWriter(parseInput.OutputDirectory,
-                        parseInput.RawFileNameWithoutExtension);
-                    metadataWriter.WriteMetada(rawFile, firstScanNumber, lastScanNumber);
-                    metadataWriter.WriteJsonMetada(rawFile, firstScanNumber, lastScanNumber);
+                    var metadataWriter = new MetadataWriter(parseInput.OutputDirectory, parseInput.RawFileNameWithoutExtension);
+                    if(parseInput.OutputMetadata == MetadataFormat.JSON)
+                        metadataWriter.WriteJsonMetada(rawFile, firstScanNumber, lastScanNumber);
+                    if(parseInput.OutputMetadata == MetadataFormat.TXT)
+                        metadataWriter.WriteMetada(rawFile, firstScanNumber, lastScanNumber);
+                    
                 }
 
                 SpectrumWriter spectrumWriter;
-                switch (parseInput.OutputFormat)
+                if (parseInput.OutputFormat != OutputFormat.NON)
                 {
-                    case OutputFormat.Mgf:
-                        spectrumWriter = new MgfSpectrumWriter(parseInput);
-                        break;
-                    case OutputFormat.Mzml:
-                        spectrumWriter = new MzMlSpectrumWriter(parseInput);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
+                    switch (parseInput.OutputFormat)
+                    {
+                        case OutputFormat.Mgf:
+                            spectrumWriter = new MgfSpectrumWriter(parseInput);
+                            spectrumWriter.Write(rawFile, firstScanNumber, lastScanNumber);
+                            break;
+                        case OutputFormat.Mzml:
+                            spectrumWriter = new MzMlSpectrumWriter(parseInput);
+                            spectrumWriter.Write(rawFile, firstScanNumber, lastScanNumber);
+                            break;
+                      }
+                    
                 }
-                spectrumWriter.Write(rawFile, firstScanNumber, lastScanNumber);
 
                 Log.Info("Finished parsing " + parseInput.RawFilePath);
             }

--- a/RawFileParser.cs
+++ b/RawFileParser.cs
@@ -76,6 +76,7 @@ namespace ThermoRawFileParser
                     var metadataWriter = new MetadataWriter(parseInput.OutputDirectory,
                         parseInput.RawFileNameWithoutExtension);
                     metadataWriter.WriteMetada(rawFile, firstScanNumber, lastScanNumber);
+                    metadataWriter.WriteJsonMetada(rawFile, firstScanNumber, lastScanNumber);
                 }
 
                 SpectrumWriter spectrumWriter;

--- a/ThermoRawFileParser.csproj
+++ b/ThermoRawFileParser.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RawFileParser.cs" />
     <Compile Include="Writer\ISpectrumWriter.cs" />
+    <Compile Include="Writer\Metadata.cs" />
     <Compile Include="Writer\MetadataWriter.cs" />
     <Compile Include="Writer\MgfSpectrumWriter.cs" />
     <Compile Include="Writer\MzMlSpectrumWriter.cs" />

--- a/ThermoRawFileParserTest/Tests.cs
+++ b/ThermoRawFileParserTest/Tests.cs
@@ -58,5 +58,27 @@ namespace ThermoRawFileParserTest
             Assert.AreEqual("1", testMzMl.run.chromatogramList.count);
             Assert.AreEqual(1, testMzMl.run.chromatogramList.chromatogram.Length);
         }
+        
+        [Test]
+        public void TestMetadata()
+        {
+            // Get temp path for writing the test mzML
+            var tempFilePath = Path.GetTempPath();
+
+            var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"small.RAW");
+            var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mgf, false, true, false,
+                "coll", "run", "sub");
+
+            var rawFileParser = new RawFileParser();
+            RawFileParser.Parse(parseInput);
+
+            // Do this for the mzLib library issue
+            var tempFileName = Path.GetTempPath() + "elements.dat";
+            UsefulProteomicsDatabases.Loaders.LoadElements(tempFileName);
+
+            var mgfData = Mgf.LoadAllStaticData(Path.Combine(tempFilePath, "small.mgf"));
+            Assert.AreEqual(34, mgfData.NumSpectra);
+            Assert.IsEmpty(mgfData.GetMS1Scans());
+        }
     }
 }

--- a/ThermoRawFileParserTest/Tests.cs
+++ b/ThermoRawFileParserTest/Tests.cs
@@ -65,7 +65,7 @@ namespace ThermoRawFileParserTest
             // Get temp path for writing the test mzML
             var tempFilePath = Path.GetTempPath();
 
-            var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"small.RAW");
+            var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"small.raw");
             var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mgf, false, true, false,
                 "coll", "run", "sub");
 

--- a/ThermoRawFileParserTest/Tests.cs
+++ b/ThermoRawFileParserTest/Tests.cs
@@ -18,7 +18,7 @@ namespace ThermoRawFileParserTest
             var tempFilePath = Path.GetTempPath();
 
             var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"small.RAW");
-            var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mgf, false, false, false,
+            var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mgf, false, MetadataFormat.NON, false,
                 "coll",
                 "run", "sub");
 
@@ -41,7 +41,7 @@ namespace ThermoRawFileParserTest
             var tempFilePath = Path.GetTempPath();
 
             var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"small.RAW");
-            var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mzml, false, false, false,
+            var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mzml, false, MetadataFormat.NON, false,
                 "coll", "run", "sub");
 
             var rawFileParser = new RawFileParser();
@@ -66,7 +66,7 @@ namespace ThermoRawFileParserTest
             var tempFilePath = Path.GetTempPath();
 
             var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"small.raw");
-            var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mgf, false, true, false,
+            var parseInput = new ParseInput(testRawFile, tempFilePath, OutputFormat.Mgf, false, MetadataFormat.JSON, false,
                 "coll", "run", "sub");
 
             var rawFileParser = new RawFileParser();

--- a/ThermoRawFileParserTest/packages.config
+++ b/ThermoRawFileParserTest/packages.config
@@ -6,4 +6,5 @@
   <package id="NUnit" version="3.10.1" targetFramework="net471" />
   <package id="PSI_Interface" version="1.3.22" targetFramework="net471" />
   <package id="ThermoFisher.CommonCore.RawFileReader" version="4.0.26" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="11.0.0.0" targetFramework="net471" />
 </packages>

--- a/Writer/Metadata.cs
+++ b/Writer/Metadata.cs
@@ -13,10 +13,10 @@ namespace ThermoRawFileParser.Writer
         private List<Dictionary<string, CVTerm>> instrumentProperties = new List<Dictionary<string, CVTerm>>();
 
         /** Scan Settings **/
-        private List<Dictionary<String, CVTerm>> scanSettings = new List<Dictionary<string, CVTerm>>();
+        private List<Dictionary<String, Object>> scanSettings = new List<Dictionary<string, Object>>();
 
         /** MS and MS data including number of MS and MS/MS **/
-        private List<Dictionary<String, CVTerm>> msData = new List<Dictionary<string, CVTerm>>(); 
+        private List<Dictionary<String, Object>> msData = new List<Dictionary<string, Object>>(); 
         
         private List<Dictionary<string, string>> sampleData = new List<Dictionary<string, string>>();
         
@@ -27,7 +27,7 @@ namespace ThermoRawFileParser.Writer
 
         public Metadata(List<Dictionary<string, string>> fileProperties,
             List<Dictionary<string, CVTerm>> instrumentProperties,
-            List<Dictionary<string, CVTerm>> msData)
+            List<Dictionary<string, Object>> msData)
         {
             this.fileProperties = fileProperties;
             this.instrumentProperties = instrumentProperties;
@@ -38,11 +38,11 @@ namespace ThermoRawFileParser.Writer
 
         public List<Dictionary<string, CVTerm>> InstrumentProperties => instrumentProperties;
 
-        public List<Dictionary<string, CVTerm>> MsData => msData;
+        public List<Dictionary<string, Object>> MsData => msData;
 
         public List<Dictionary<string, string>> SampleData => sampleData;
 
-        public List<Dictionary<string, CVTerm>> ScanSettings => scanSettings;
+        public List<Dictionary<string, Object>> ScanSettings => scanSettings;
 
         /**
          * Add a File property to the fileProperties 
@@ -61,16 +61,16 @@ namespace ThermoRawFileParser.Writer
             instrumentProperties.Add(dic);
         }
 
-        public void addScanSetting(string key, CVTerm value)
+        public void addScanSetting(string key, Object value)
         {
-            var dic = new Dictionary<string, CVTerm>();
+            var dic = new Dictionary<string, Object>();
             dic.Add(key, value);
             scanSettings.Add(dic);
         }
 
-        public void addMSData(string key, CVTerm value)
+        public void addMSData(string key, Object value)
         {
-            var dic = new Dictionary<string, CVTerm>();
+            var dic = new Dictionary<string, Object>();
             dic.Add(key, value);
             msData.Add(dic);
         }
@@ -96,16 +96,54 @@ namespace ThermoRawFileParser.Writer
 
         public CVTerm(string accession, string cvLabel, string name, string value)
         {
-            this.acc = accession;
-            this.cvLabelID = cvLabel;
-            this.cvName = name;
-            this.cvValue = value;
+            acc = accession;
+            cvLabelID = cvLabel;
+            cvName = name;
+            cvValue = value;
         }
 
         public string accession => acc;
         public string cvLabel => cvLabelID;
         public string name => cvName;
         public string value => cvValue;
+
+       
+        public override int GetHashCode()
+        {
+            return CvTermComparer.GetHashCode(this); 
+            
+        }
+
+        private sealed class CvTermEqualityComparer : IEqualityComparer<CVTerm>
+        {
+            public bool Equals(CVTerm x, CVTerm y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+                if (x.GetType() != y.GetType()) return false;
+                return string.Equals(x.acc, y.acc) && string.Equals(x.cvLabelID, y.cvLabelID) && string.Equals(x.cvName, y.cvName) && string.Equals(x.cvValue, y.cvValue);
+            }
+
+            public int GetHashCode(CVTerm obj)
+            {
+                unchecked
+                {
+                    var hashCode = (obj.acc != null ? obj.acc.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (obj.cvLabelID != null ? obj.cvLabelID.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (obj.cvName != null ? obj.cvName.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (obj.cvValue != null ? obj.cvValue.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
+        }
+
+        public static IEqualityComparer<CVTerm> CvTermComparer { get; } = new CvTermEqualityComparer();
+
+        public override bool Equals(object obj)
+        {
+            return CvTermComparer.Equals(obj);
+        }
     }
     
 }

--- a/Writer/Metadata.cs
+++ b/Writer/Metadata.cs
@@ -80,13 +80,11 @@ namespace ThermoRawFileParser.Writer
             var dic = new Dictionary<string, string>();
             dic.Add(key, value);
             sampleData.Add(dic);
-        }
-        
-        
+        }     
     }
 
-    public class CVTerm
-    {
+    public class CVTerm{
+        
         private string acc = "";
         private string cvLabelID ="";
         private string cvName = "";

--- a/Writer/Metadata.cs
+++ b/Writer/Metadata.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.Remoting.Messaging;
 using ThermoRawFileParser.Writer.MzML;
 
 namespace ThermoRawFileParser.Writer
@@ -11,13 +10,15 @@ namespace ThermoRawFileParser.Writer
         private List<Dictionary<string, string>> fileProperties = new List<Dictionary<string, string>>();
 
         /** The Instruments properties contains the information of the instrument **/ 
-        private List<Dictionary<string, CVParamType>> instrumentProperties = new List<Dictionary<string, CVParamType>>();
+        private List<Dictionary<string, CVTerm>> instrumentProperties = new List<Dictionary<string, CVTerm>>();
 
         /** Scan Settings **/
-        private List<Dictionary<String, CVParamType>> scanSettings = new List<Dictionary<string, CVParamType>>();
+        private List<Dictionary<String, CVTerm>> scanSettings = new List<Dictionary<string, CVTerm>>();
 
         /** MS and MS data including number of MS and MS/MS **/
-        private List<Dictionary<String, CVParamType>> msData = new List<Dictionary<string, CVParamType>>(); 
+        private List<Dictionary<String, CVTerm>> msData = new List<Dictionary<string, CVTerm>>(); 
+        
+        private List<Dictionary<string, string>> sampleData = new List<Dictionary<string, string>>();
         
         /**
          * Default constructor 
@@ -25,8 +26,8 @@ namespace ThermoRawFileParser.Writer
         public Metadata(){}
 
         public Metadata(List<Dictionary<string, string>> fileProperties,
-            List<Dictionary<string, CVParamType>> instrumentProperties,
-            List<Dictionary<string, CVParamType>> msData)
+            List<Dictionary<string, CVTerm>> instrumentProperties,
+            List<Dictionary<string, CVTerm>> msData)
         {
             this.fileProperties = fileProperties;
             this.instrumentProperties = instrumentProperties;
@@ -35,9 +36,13 @@ namespace ThermoRawFileParser.Writer
 
         public List<Dictionary<string, string>> FileProperties => fileProperties;
 
-        public List<Dictionary<string, CVParamType>> InstrumentProperties => instrumentProperties;
+        public List<Dictionary<string, CVTerm>> InstrumentProperties => instrumentProperties;
 
-        public List<Dictionary<string, CVParamType>> MsData => msData;
+        public List<Dictionary<string, CVTerm>> MsData => msData;
+
+        public List<Dictionary<string, string>> SampleData => sampleData;
+
+        public List<Dictionary<string, CVTerm>> ScanSettings => scanSettings;
 
         /**
          * Add a File property to the fileProperties 
@@ -49,25 +54,60 @@ namespace ThermoRawFileParser.Writer
             fileProperties.Add(dic);
         }
 
-        public void addInstrumentProperty(string key, CVParamType value)
+        public void addInstrumentProperty(string key, CVTerm value)
         {
-            var dic = new Dictionary<string, CVParamType>();
+            var dic = new Dictionary<string, CVTerm>();
             dic.Add(key, value);
             instrumentProperties.Add(dic);
         }
 
-        public void addScanSetting(string key, CVParamType value)
+        public void addScanSetting(string key, CVTerm value)
         {
-            var dic = new Dictionary<string, CVParamType>();
+            var dic = new Dictionary<string, CVTerm>();
             dic.Add(key, value);
             scanSettings.Add(dic);
         }
 
-        public void addMSData(string key, CVParamType value)
+        public void addMSData(string key, CVTerm value)
         {
-            var dic = new Dictionary<string, CVParamType>();
+            var dic = new Dictionary<string, CVTerm>();
             dic.Add(key, value);
             msData.Add(dic);
         }
+
+        public void addSampleProperty(string key, string value)
+        {
+            var dic = new Dictionary<string, string>();
+            dic.Add(key, value);
+            sampleData.Add(dic);
+        }
+        
+        
     }
+
+    public class CVTerm
+    {
+        private string acc = "";
+        private string cvLabelID ="";
+        private string cvName = "";
+        private string cvValue ="";
+
+        public CVTerm()
+        {
+        }
+
+        public CVTerm(string accession, string cvLabel, string name, string value)
+        {
+            this.acc = accession;
+            this.cvLabelID = cvLabel;
+            this.cvName = name;
+            this.cvValue = value;
+        }
+
+        public string accession => acc;
+        public string cvLabel => cvLabelID;
+        public string name => cvName;
+        public string value => cvValue;
+    }
+    
 }

--- a/Writer/Metadata.cs
+++ b/Writer/Metadata.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
+using ThermoRawFileParser.Writer.MzML;
+
+namespace ThermoRawFileParser.Writer
+{
+    public class Metadata
+    {
+        /** The general Path properties contains: RAW path , RAW file version **/
+        private List<Dictionary<string, string>> fileProperties = new List<Dictionary<string, string>>();
+
+        /** The Instruments properties contains the information of the instrument **/ 
+        private List<Dictionary<string, CVParamType>> instrumentProperties = new List<Dictionary<string, CVParamType>>();
+
+        /** Scan Settings **/
+        private List<Dictionary<String, CVParamType>> scanSettings = new List<Dictionary<string, CVParamType>>();
+
+        /** MS and MS data including number of MS and MS/MS **/
+        private List<Dictionary<String, CVParamType>> msData = new List<Dictionary<string, CVParamType>>(); 
+        
+        /**
+         * Default constructor 
+         */
+        public Metadata(){}
+
+        public Metadata(List<Dictionary<string, string>> fileProperties,
+            List<Dictionary<string, CVParamType>> instrumentProperties,
+            List<Dictionary<string, CVParamType>> msData)
+        {
+            this.fileProperties = fileProperties;
+            this.instrumentProperties = instrumentProperties;
+            this.msData = msData;
+        }
+
+        public List<Dictionary<string, string>> FileProperties => fileProperties;
+
+        public List<Dictionary<string, CVParamType>> InstrumentProperties => instrumentProperties;
+
+        public List<Dictionary<string, CVParamType>> MsData => msData;
+
+        /**
+         * Add a File property to the fileProperties 
+         */
+        public void addFileProperty(String key, String value)
+        {
+            var dic = new Dictionary<string, string>();
+            dic.Add(key, value);
+            fileProperties.Add(dic);
+        }
+
+        public void addInstrumentProperty(string key, CVParamType value)
+        {
+            var dic = new Dictionary<string, CVParamType>();
+            dic.Add(key, value);
+            instrumentProperties.Add(dic);
+        }
+
+        public void addScanSetting(string key, CVParamType value)
+        {
+            var dic = new Dictionary<string, CVParamType>();
+            dic.Add(key, value);
+            scanSettings.Add(dic);
+        }
+
+        public void addMSData(string key, CVParamType value)
+        {
+            var dic = new Dictionary<string, CVParamType>();
+            dic.Add(key, value);
+            msData.Add(dic);
+        }
+    }
+}

--- a/Writer/MetadataWriter.cs
+++ b/Writer/MetadataWriter.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using ThermoFisher.CommonCore.Data.Interfaces;
+using ThermoRawFileParser.Writer.MzML;
 
 namespace ThermoRawFileParser.Writer
 {
@@ -87,39 +89,42 @@ namespace ThermoRawFileParser.Writer
             
             var metadata = new Metadata();
             
-            metadata.addFileProperty("file-path", rawFile.FileName);
-            metadata.addFileProperty("file-version", rawFile.FileHeader.Revision.ToString());
+            /** File Properties **/
+            metadata.addFileProperty("path", rawFile.FileName);
+            metadata.addFileProperty("version", rawFile.FileHeader.Revision.ToString());
             metadata.addFileProperty("creation-date", rawFile.FileHeader.CreationDate.ToString());
+            metadata.addFileProperty("number-instruments", rawFile.InstrumentCount.ToString());
+            metadata.addFileProperty("description", rawFile.FileHeader.FileDescription);
+            
+            /** Sample Properties **/
+            metadata.addSampleProperty("name", rawFile.SampleInformation.SampleName);
+            metadata.addSampleProperty("id", rawFile.SampleInformation.SampleId);
+            metadata.addSampleProperty("type", rawFile.SampleInformation.SampleType.ToString());
+            metadata.addSampleProperty("comment", rawFile.SampleInformation.Comment);
+            metadata.addSampleProperty("vial", rawFile.SampleInformation.Vial);
+            metadata.addSampleProperty("volume", rawFile.SampleInformation.SampleVolume.ToString()); 
+            metadata.addSampleProperty("injection-volume", rawFile.SampleInformation.InjectionVolume.ToString());
+            metadata.addSampleProperty("row-number", rawFile.SampleInformation.RowNumber.ToString());
+            metadata.addSampleProperty("dilution-factor", rawFile.SampleInformation.DilutionFactor.ToString());
+            
+            metadata.addScanSetting("scan-start-time", new CVTerm("MS:1000016", "MS", "scan start time",startTime.ToString()));
+            
             
             // Collect the metadata
             var output = new List<string>
             {
                 $"Created by=[MS, MS:1000529, created_by, {rawFile.FileHeader.WhoCreatedId}]",
-                "Number of instruments=" + rawFile.InstrumentCount,
-                "Description=" + rawFile.FileHeader.FileDescription,
                 $"Instrument model=[MS, MS:1000494, Thermo Scientific instrument model, {rawFile.GetInstrumentData().Model}]",
                 "Instrument name=" + rawFile.GetInstrumentData().Name,
                 $"Instrument serial number=[MS, MS:1000529, instrument serial number, {rawFile.GetInstrumentData().SerialNumber}]",
-                $"Software version=[NCIT, NCIT:C111093, Software Version, {rawFile.GetInstrumentData().SoftwareVersion}]",
-                "Firmware version=" + rawFile.GetInstrumentData().HardwareVersion,
+                $"Software version=[NCIT, NCIT:C111093, Software Version, {rawFile.GetInstrumentData().SoftwareVersion}]","Firmware version=" + rawFile.GetInstrumentData().HardwareVersion,
                 "Units=" + rawFile.GetInstrumentData().Units,
                 $"Mass resolution=[MS, MS:1000011, mass resolution, {rawFile.RunHeaderEx.MassResolution:F3}]",
                 $"Number of scans={rawFile.RunHeaderEx.SpectraCount}",
                 $"Scan range={firstScanNumber};{lastScanNumber}",
-                $"Scan start time=[MS, MS:1000016, scan start time, {startTime:F2}]",
                 $"Time range={startTime:F2};{endTime:F2}",
                 $"Mass range={rawFile.RunHeaderEx.LowMass:F4};{rawFile.RunHeaderEx.HighMass:F4}",
-                "",
-                "#Sample information",
-                "Sample name=" + rawFile.SampleInformation.SampleName,
-                "Sample id=" + rawFile.SampleInformation.SampleId,
-                "Sample type=" + rawFile.SampleInformation.SampleType,
-                "Sample comment=" + rawFile.SampleInformation.Comment,
-                "Sample vial=" + rawFile.SampleInformation.Vial,
-                "Sample volume=" + rawFile.SampleInformation.SampleVolume,
-                "Sample injection volume=" + rawFile.SampleInformation.InjectionVolume,
-                "Sample row number=" + rawFile.SampleInformation.RowNumber,
-                "Sample dilution factor=" + rawFile.SampleInformation.DilutionFactor
+                ""
             };
 
             // Write the meta data to file

--- a/Writer/MetadataWriter.cs
+++ b/Writer/MetadataWriter.cs
@@ -77,7 +77,7 @@ namespace ThermoRawFileParser.Writer
             };
 
             // Write the meta data to file
-            File.WriteAllLines(_outputDirectory + "/" + _rawFileNameWithoutExtension + "_metadata", output.ToArray());
+            File.WriteAllLines(_outputDirectory + "/" + _rawFileNameWithoutExtension + "-metadata.txt", output.ToArray());
            
         }
         

--- a/Writer/MetadataWriter.cs
+++ b/Writer/MetadataWriter.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.SqlServer.Server;
 using Newtonsoft.Json;
+using ThermoFisher.CommonCore.Data.Business;
+using ThermoFisher.CommonCore.Data.FilterEnums;
 using ThermoFisher.CommonCore.Data.Interfaces;
 using ThermoRawFileParser.Writer.MzML;
 
@@ -9,6 +12,9 @@ namespace ThermoRawFileParser.Writer
 {
     public class MetadataWriter
     {
+        private static readonly log4net.ILog Log =
+            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        
         private readonly string _outputDirectory;
         private readonly string _rawFileNameWithoutExtension;
 
@@ -107,29 +113,100 @@ namespace ThermoRawFileParser.Writer
             metadata.addSampleProperty("row-number", rawFile.SampleInformation.RowNumber.ToString());
             metadata.addSampleProperty("dilution-factor", rawFile.SampleInformation.DilutionFactor.ToString());
             
-            metadata.addScanSetting("scan-start-time", new CVTerm("MS:1000016", "MS", "scan start time",startTime.ToString()));
+            metadata.addScanSetting("start-time", new CVTerm("MS:1000016", "MS", "scan start time",startTime.ToString()));
+            metadata.addScanSetting("resolution", new CVTerm("MS:1000011", "MS", "mass resolution", rawFile.RunHeaderEx.MassResolution.ToString()));
+            metadata.addScanSetting("tolerance-unit", new CVTerm("UO:0000002", "MS", "mass unit", rawFile.GetInstrumentData().Units.ToString()));
+            metadata.addScanSetting("number-scans", new CVTerm("", "", "", rawFile.RunHeaderEx.SpectraCount.ToString()));
+            metadata.addScanSetting("scan-range", new CVTerm("", "", "", firstScanNumber + ":" + lastScanNumber));
+            metadata.addScanSetting("time-range", new CVTerm("","","", startTime + ":" + endTime));
+            metadata.addScanSetting("mass-range", new CVTerm("", "", "", rawFile.RunHeaderEx.LowMass + ":" + rawFile.RunHeaderEx.HighMass)); 
             
+            metadata.addInstrumentProperty("model", new CVTerm("MS:1000494", "MS","Thermo Scientific instrument model", rawFile.GetInstrumentData().Model));
+            metadata.addInstrumentProperty("name", new CVTerm("MS:1000496", "MS","instrument attribute", rawFile.GetInstrumentData().Name));
+            metadata.addInstrumentProperty("serial", new CVTerm("MS:1000529", "MS", "instrument serial number", rawFile.GetInstrumentData().SerialNumber));
             
-            // Collect the metadata
-            var output = new List<string>
-            {
-                $"Created by=[MS, MS:1000529, created_by, {rawFile.FileHeader.WhoCreatedId}]",
-                $"Instrument model=[MS, MS:1000494, Thermo Scientific instrument model, {rawFile.GetInstrumentData().Model}]",
-                "Instrument name=" + rawFile.GetInstrumentData().Name,
-                $"Instrument serial number=[MS, MS:1000529, instrument serial number, {rawFile.GetInstrumentData().SerialNumber}]",
-                $"Software version=[NCIT, NCIT:C111093, Software Version, {rawFile.GetInstrumentData().SoftwareVersion}]","Firmware version=" + rawFile.GetInstrumentData().HardwareVersion,
-                "Units=" + rawFile.GetInstrumentData().Units,
-                $"Mass resolution=[MS, MS:1000011, mass resolution, {rawFile.RunHeaderEx.MassResolution:F3}]",
-                $"Number of scans={rawFile.RunHeaderEx.SpectraCount}",
-                $"Scan range={firstScanNumber};{lastScanNumber}",
-                $"Time range={startTime:F2};{endTime:F2}",
-                $"Mass range={rawFile.RunHeaderEx.LowMass:F4};{rawFile.RunHeaderEx.HighMass:F4}",
-                ""
-            };
+            metadata.addMSData("ms-number", new CVTerm("","","", ""));
+            
+            var msTypes = new Dictionary<string, int>();
+            double minTime = 1000000000000000;
+            double maxTime = 0;
+            double minMz = 1000000000000000000;
+            double maxMz = 0;
+            double minCharge = 100000000000000;
+            double maxCharge = 0;
 
+            for (var scanNumber = firstScanNumber; scanNumber <= lastScanNumber; scanNumber++)
+            {
+                var scan = Scan.FromFile(rawFile, scanNumber);
+                var time = rawFile.RetentionTimeFromScanNumber(scanNumber);
+
+                // Get the scan filter for this scan number
+                var scanFilter = rawFile.GetFilterForScanNumber(scanNumber);
+
+                // Get the scan event for this scan number
+                var scanEvent = rawFile.GetScanEventForScanNumber(scanNumber);
+
+                // Only consider MS2 spectra
+                if (msTypes.ContainsKey(scanFilter.MSOrder.ToString()))
+                {
+                    var value = msTypes[scanFilter.MSOrder.ToString()];
+                    value = value + 1;
+                    msTypes[scanFilter.MSOrder.ToString()] = value; 
+                }else 
+                    msTypes.Add(scanFilter.MSOrder.ToString(), 1);
+
+                if (time > maxTime)
+                    maxTime = time;
+                if (time < minTime)
+                    minTime = time; 
+                
+                if (scanFilter.MSOrder == MSOrderType.Ms2)
+                   {
+                       if (scanEvent.ScanData == ScanDataType.Centroid || (scanEvent.ScanData == ScanDataType.Profile)){
+                            try
+                            {
+                                var reaction = scanEvent.GetReaction(0);
+                                var precursorMass = reaction.PrecursorMass;
+                                if (precursorMass > maxMz)
+                                    maxMz = precursorMass;
+                                if (precursorMass < minMz)
+                                    minMz = precursorMass; 
+                            }
+                            catch (ArgumentOutOfRangeException exception)
+                            {
+                                Log.Warn("No reaction found for scan " + scanNumber);
+                            }
+
+                            // trailer extra data list
+                            var trailerData = rawFile.GetTrailerExtraInformation(scanNumber);
+                            for (var i = 0; i < trailerData.Length; i++)
+                            {
+                                if (trailerData.Labels[i] == "Charge State:")
+                                {
+
+                                    if (Int32.Parse(trailerData.Values[i]) > maxCharge)
+                                        maxCharge = Int32.Parse(trailerData.Values[i]); 
+                                    
+                                    if (Int32.Parse(trailerData.Values[i]) < minCharge)
+                                        maxCharge = Int32.Parse(trailerData.Values[i]); 
+
+                                }
+                            }
+                           
+                       }
+                    }
+            }
+
+            if (minCharge == 100000000000000)
+            {
+                minCharge = 0;
+            }
+            
+            
             // Write the meta data to file
             var json = JsonConvert.SerializeObject(metadata);
-            System.IO.File.WriteAllText(_outputDirectory + "/" + _rawFileNameWithoutExtension + "-metadata.json", json);
+            json.Replace("\r\n", "\n");
+            File.WriteAllText(_outputDirectory + "/" + _rawFileNameWithoutExtension + "-metadata.json", json);
 
         }
     }

--- a/Writer/MetadataWriter.cs
+++ b/Writer/MetadataWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using Newtonsoft.Json;
 using ThermoFisher.CommonCore.Data.Interfaces;
 
 namespace ThermoRawFileParser.Writer
@@ -69,6 +70,9 @@ namespace ThermoRawFileParser.Writer
 
             // Write the meta data to file
             File.WriteAllLines(_outputDirectory + "/" + _rawFileNameWithoutExtension + "_metadata", output.ToArray());
+            var json = JsonConvert.SerializeObject(output.ToArray());
+            System.IO.File.WriteAllText(_outputDirectory + "/" + _rawFileNameWithoutExtension + ".json", json);
+
         }
     }
 }

--- a/Writer/MetadataWriter.cs
+++ b/Writer/MetadataWriter.cs
@@ -70,8 +70,61 @@ namespace ThermoRawFileParser.Writer
 
             // Write the meta data to file
             File.WriteAllLines(_outputDirectory + "/" + _rawFileNameWithoutExtension + "_metadata", output.ToArray());
-            var json = JsonConvert.SerializeObject(output.ToArray());
-            System.IO.File.WriteAllText(_outputDirectory + "/" + _rawFileNameWithoutExtension + ".json", json);
+           
+        }
+        
+        /// <summary>
+        /// Write the RAW file metadata to file.
+        /// <param name="rawFile">the RAW file object</param>
+        /// <param name="firstScanNumber">the first scan number</param>
+        /// <param name="lastScanNumber">the last scan number</param>
+        /// </summary>
+        public void WriteJsonMetada(IRawDataPlus rawFile, int firstScanNumber, int lastScanNumber)
+        {
+            // Get the start and end time from the RAW file
+            var startTime = rawFile.RunHeaderEx.StartTime;
+            var endTime = rawFile.RunHeaderEx.EndTime;
+            
+            var metadata = new Metadata();
+            
+            metadata.addFileProperty("file-path", rawFile.FileName);
+            metadata.addFileProperty("file-version", rawFile.FileHeader.Revision.ToString());
+            metadata.addFileProperty("creation-date", rawFile.FileHeader.CreationDate.ToString());
+            
+            // Collect the metadata
+            var output = new List<string>
+            {
+                $"Created by=[MS, MS:1000529, created_by, {rawFile.FileHeader.WhoCreatedId}]",
+                "Number of instruments=" + rawFile.InstrumentCount,
+                "Description=" + rawFile.FileHeader.FileDescription,
+                $"Instrument model=[MS, MS:1000494, Thermo Scientific instrument model, {rawFile.GetInstrumentData().Model}]",
+                "Instrument name=" + rawFile.GetInstrumentData().Name,
+                $"Instrument serial number=[MS, MS:1000529, instrument serial number, {rawFile.GetInstrumentData().SerialNumber}]",
+                $"Software version=[NCIT, NCIT:C111093, Software Version, {rawFile.GetInstrumentData().SoftwareVersion}]",
+                "Firmware version=" + rawFile.GetInstrumentData().HardwareVersion,
+                "Units=" + rawFile.GetInstrumentData().Units,
+                $"Mass resolution=[MS, MS:1000011, mass resolution, {rawFile.RunHeaderEx.MassResolution:F3}]",
+                $"Number of scans={rawFile.RunHeaderEx.SpectraCount}",
+                $"Scan range={firstScanNumber};{lastScanNumber}",
+                $"Scan start time=[MS, MS:1000016, scan start time, {startTime:F2}]",
+                $"Time range={startTime:F2};{endTime:F2}",
+                $"Mass range={rawFile.RunHeaderEx.LowMass:F4};{rawFile.RunHeaderEx.HighMass:F4}",
+                "",
+                "#Sample information",
+                "Sample name=" + rawFile.SampleInformation.SampleName,
+                "Sample id=" + rawFile.SampleInformation.SampleId,
+                "Sample type=" + rawFile.SampleInformation.SampleType,
+                "Sample comment=" + rawFile.SampleInformation.Comment,
+                "Sample vial=" + rawFile.SampleInformation.Vial,
+                "Sample volume=" + rawFile.SampleInformation.SampleVolume,
+                "Sample injection volume=" + rawFile.SampleInformation.InjectionVolume,
+                "Sample row number=" + rawFile.SampleInformation.RowNumber,
+                "Sample dilution factor=" + rawFile.SampleInformation.DilutionFactor
+            };
+
+            // Write the meta data to file
+            var json = JsonConvert.SerializeObject(metadata);
+            System.IO.File.WriteAllText(_outputDirectory + "/" + _rawFileNameWithoutExtension + "-metadata.json", json);
 
         }
     }

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -141,7 +141,7 @@ namespace ThermoRawFileParser.Writer
                 id = ParseInput.RawFileName,
                 name = ParseInput.RawFileNameWithoutExtension,
                 location = ParseInput.RawFilePath,
-                cvParam = new CVParamType[3]
+                cvParam = new CVParamType[4]
             };
 
             mzMl.fileDescription.sourceFileList.sourceFile[0].cvParam[0] = new CVParamType
@@ -156,14 +156,21 @@ namespace ThermoRawFileParser.Writer
                 accession = "MS:1000568",
                 name = "MD5",
                 cvRef = "MS",
-                value = CalculateChecksum()
+                value = CalculateMD5Checksum()
             };
             mzMl.fileDescription.sourceFileList.sourceFile[0].cvParam[2] = new CVParamType
             {
-                accession = "MS:1000563",
-                name = "Thermo RAW format",
+                accession = "MS:1000568",
+                name = "MD5",
                 cvRef = "MS",
-                value = ""
+                value = CalculateMD5Checksum()
+            };
+            mzMl.fileDescription.sourceFileList.sourceFile[0].cvParam[3] = new CVParamType
+            {
+                accession = "MS:1000569",
+                name = "SHA-1",
+                cvRef = "MS",
+                value = CalculateSHAChecksum()
             };
 
             mzMl.fileDescription.fileContent.cvParam = new CVParamType[2];
@@ -1252,13 +1259,30 @@ namespace ThermoRawFileParser.Writer
         /// Calculate the RAW file checksum
         /// </summary>
         /// <returns>the checksum string</returns>
-        private string CalculateChecksum()
+        private string CalculateMD5Checksum()
         {
             using (var md5 = MD5.Create())
             {
                 using (var stream = File.OpenRead(ParseInput.RawFilePath))
                 {
                     var hash = md5.ComputeHash(stream);
+                    return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+                }
+            }
+        }
+        
+        
+        /// <summary>
+        /// Calculate the RAW file checksum
+        /// </summary>
+        /// <returns>the checksum string</returns>
+        private string CalculateSHAChecksum()
+        {
+            using (var sha1 = SHA1.Create())
+            {
+                using (var stream = File.OpenRead(ParseInput.RawFilePath))
+                {
+                    var hash = sha1.ComputeHash(stream);
                     return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
                 }
             }


### PR DESCRIPTION
- The new implementation can generate metadata in json format or txt. 
- The generation of the spectra or the metadata are optionals for users that want to generate the data or the metadata ot both. 