### PR TITLE
Added "file:///" to the "location" attribute of "sourceFile" element …

### DIFF
--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -162,7 +162,7 @@ namespace ThermoRawFileParser.Writer
                 _writer.WriteStartElement("sourceFile");
                 _writer.WriteAttributeString("id", SourceFileId);
                 _writer.WriteAttributeString("name", ParseInput.RawFileNameWithoutExtension);
-                _writer.WriteAttributeString("location", ParseInput.RawFilePath);
+                _writer.WriteAttributeString("location", "file:///"+ParseInput.RawFilePath);
                 SerializeCvParam(new CVParamType
                 {
                     accession = "MS:1000768",


### PR DESCRIPTION
…when converting to .mzml format to avoid problems identifying URI format when using relative path.

Search engines as MetaMorpheus do not properly identify the format of relative paths like "./raws_folder/input.raw"
and they crash just reading the .mzml even when they do not use the raw file itself.

We have experienced this problem when using .mzml files generated by ThermoRawFileConverter in galaxy as galaxy uses with the "-d" argument the relative path to its working folder "./raws_folder".
Just adding "file:///" to this relative path is enought to properly identify the type of the provided URI.

Greetings,
Carlos