### PR TITLE
Uvdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 bin/
 obj/
 *.log
-ThermoRawFileParser.sln.DotSettings.user
+*.sln.DotSettings.user
 .vs/
-
+*.csproj.user

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -504,7 +504,7 @@ namespace ThermoRawFileParser
                 {
                     if (parseInput.RawFilePath != null)
                     {
-                        parseInput.OutputDirectory = Path.GetDirectoryName(parseInput.RawFilePath);
+                        parseInput.OutputDirectory = Path.GetDirectoryName(Path.GetFullPath(parseInput.RawFilePath));
                     }
                     else if (parseInput.RawDirectoryPath != null)
                     {

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -17,7 +17,7 @@ namespace ThermoRawFileParser
         private static readonly ILog Log =
             LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public const string Version = "1.3.0-pre";
+        public const string Version = "1.3.0";
 
         public static void Main(string[] args)
         {

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -17,7 +17,7 @@ namespace ThermoRawFileParser
         private static readonly ILog Log =
             LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public const string Version = "1.2.3";
+        public const string Version = "1.3.0-pre";
 
         public static void Main(string[] args)
         {

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -410,6 +410,11 @@ namespace ThermoRawFileParser
                     v => parseInput.NoZlibCompression = v != null
                 },
                 {
+                    "a|allDetectors",
+                    "Extract additonal detector data: UV/PDA etc",
+                    v => parseInput.AllDetectors = v != null
+                },
+                {
                     "l=|logging=", "Optional logging level: 0 for silent, 1 for verbose.",
                     v => logFormatString = v
                 },

--- a/ParseInput.cs
+++ b/ParseInput.cs
@@ -65,6 +65,8 @@ namespace ThermoRawFileParser
 
         public bool NoZlibCompression { get; set; }
 
+        public bool AllDetectors { get; set; }
+
         public LogFormat LogFormat { get; set; }
 
         public bool IgnoreInstrumentErrors { get; set; }
@@ -98,6 +100,7 @@ namespace ThermoRawFileParser
             NoZlibCompression = false;
             LogFormat = LogFormat.DEFAULT;
             IgnoreInstrumentErrors = false;
+            AllDetectors = false;
         }
 
         public ParseInput(string rawFilePath, string rawDirectoryPath, string outputDirectory, OutputFormat outputFormat

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ optional subcommands are xic|query (use [subcommand] -h for more info]):
   -z, --noZlibCompression    Don't use zlib compression for the m/z ratios and
                                intensities. By default zlib compression is
                                enabled.
+  -a, --allDetectors         Extract additonal detector data: UV/PDA etc
   -l, --logging=VALUE        Optional logging level: 0 for silent, 1 for
                                verbose.
   -e, --ignoreInstrumentErrors

--- a/ThermoRawFileParser.csproj.user
+++ b/ThermoRawFileParser.csproj.user
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <StartArguments>-i=C:\Users\Iman\Desktop\RawFiles\FileReaderTest\blacktea_1.raw -f=2 -o .\</StartArguments>
+    <StartArguments>-i=C:\Code\QC_MSDDA_UV.raw -f=1 -o=C:\Code -a</StartArguments>
   </PropertyGroup>
 </Project>

--- a/ThermoRawFileParser.csproj.user
+++ b/ThermoRawFileParser.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <StartArguments>-i=C:\Code\QC_MSDDA_UV.raw -f=1 -o=C:\Code -a</StartArguments>
-  </PropertyGroup>
-</Project>

--- a/ThermoRawFileParserTest/WriterTests.cs
+++ b/ThermoRawFileParserTest/WriterTests.cs
@@ -129,8 +129,8 @@ namespace ThermoRawFileParserTest
             var selectedZ = int.Parse(precursor.cvParam.Where(cv => cv.accession == "MS:1000041").First().value);
             Assert.AreEqual(selectedZ , 2);
 
-            var selectedI = Double.Parse(precursor.cvParam.Where(cv => cv.accession == "MS:1000042").First().value);
-            Assert.IsTrue(selectedI - 10073 < 1);
+            //var selectedI = Double.Parse(precursor.cvParam.Where(cv => cv.accession == "MS:1000042").First().value);
+            //Assert.IsTrue(selectedI - 10073 < 1);
 
             Assert.AreEqual(95, testMzMl.run.chromatogramList.chromatogram[0].defaultArrayLength);
         }

--- a/ThermoRawFileParserTest/WriterTests.cs
+++ b/ThermoRawFileParserTest/WriterTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
+using System.Net.PeerToPeer.Collaboration;
 using System.Xml.Serialization;
 using IO.Mgf;
+using MzLibUtil;
 using NUnit.Framework;
 using ThermoRawFileParser;
 using ThermoRawFileParser.Writer.MzML;
@@ -66,6 +69,8 @@ namespace ThermoRawFileParserTest
 
             Assert.AreEqual("1", testMzMl.run.chromatogramList.count);
             Assert.AreEqual(1, testMzMl.run.chromatogramList.chromatogram.Length);
+
+            Assert.AreEqual(48, testMzMl.run.chromatogramList.chromatogram[0].defaultArrayLength);
         }
 
         [Test]
@@ -97,6 +102,37 @@ namespace ThermoRawFileParserTest
             Assert.AreEqual(48, testMzMl.indexList.index[0].offset.Length);
             Assert.AreEqual("chromatogram", testMzMl.indexList.index[1].name.ToString());
             Assert.AreEqual(1, testMzMl.indexList.index[1].offset.Length);
+        }
+
+        [Test]
+        public void TestMzML_MS2()
+        {
+            // Get temp path for writing the test mzML
+            var tempFilePath = Path.GetTempPath();
+
+            var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Data/small2.RAW");
+            var parseInput = new ParseInput(testRawFile, null, tempFilePath, OutputFormat.MzML);
+
+            RawFileParser.Parse(parseInput);
+
+            // Deserialize the mzML file
+            var xmlSerializer = new XmlSerializer(typeof(mzMLType));
+            var testMzMl = (mzMLType)xmlSerializer.Deserialize(new FileStream(
+                Path.Combine(tempFilePath, "small2.mzML"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+
+            Assert.AreEqual(95, testMzMl.run.spectrumList.spectrum.Length);
+
+            var precursor = testMzMl.run.spectrumList.spectrum[16].precursorList.precursor[0].selectedIonList.selectedIon[0];
+            var selectedMz = Double.Parse(precursor.cvParam.Where(cv => cv.accession == "MS:1000744").First().value);
+            Assert.IsTrue(selectedMz - 604.7592 < 0.001);
+
+            var selectedZ = int.Parse(precursor.cvParam.Where(cv => cv.accession == "MS:1000041").First().value);
+            Assert.AreEqual(selectedZ , 2);
+
+            var selectedI = Double.Parse(precursor.cvParam.Where(cv => cv.accession == "MS:1000042").First().value);
+            Assert.IsTrue(selectedI - 10073 < 1);
+
+            Assert.AreEqual(95, testMzMl.run.chromatogramList.chromatogram[0].defaultArrayLength);
         }
     }
 }

--- a/Writer/MgfSpectrumWriter.cs
+++ b/Writer/MgfSpectrumWriter.cs
@@ -65,7 +65,7 @@ namespace ThermoRawFileParser.Writer
                         IReaction reaction = GetReaction(scanEvent, scanNumber);
 
                         Writer.WriteLine("BEGIN IONS");
-                        Writer.WriteLine($"TITLE={ConstructSpectrumTitle(scanNumber)}");
+                        Writer.WriteLine($"TITLE={ConstructSpectrumTitle((int)Device.MS, 1, scanNumber)}");
                         Writer.WriteLine($"SCANS={scanNumber}");
                         Writer.WriteLine(
                             $"RTINSECONDS={(time * 60).ToString(CultureInfo.InvariantCulture)}");

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -1847,23 +1847,24 @@ namespace ThermoRawFileParser.Writer
                 });
             }
  
-            if (selectedIonMz > ZeroDelta)
-            {
-                var selectedIonIntensity = CalculatePrecursorPeakIntensity(_rawFile, precursorScanNumber, selectedIonMz);
-                if (selectedIonIntensity != null)
-                {
-                    ionCvParams.Add(new CVParamType
-                    {
-                        name = "peak intensity",
-                        value = selectedIonIntensity.ToString(),
-                        accession = "MS:1000042",
-                        cvRef = "MS",
-                        unitAccession = "MS:1000131",
-                        unitCvRef = "MS",
-                        unitName = "number of detector counts"
-                    });
-                }
-            }
+            //Precursor intensity is disabled for now
+            //if (selectedIonMz > ZeroDelta)
+            //{
+            //    var selectedIonIntensity = CalculatePrecursorPeakIntensity(_rawFile, precursorScanNumber, selectedIonMz);
+            //    if (selectedIonIntensity != null)
+            //    {
+            //        ionCvParams.Add(new CVParamType
+            //        {
+            //            name = "peak intensity",
+            //            value = selectedIonIntensity.ToString(),
+            //            accession = "MS:1000042",
+            //            cvRef = "MS",
+            //            unitAccession = "MS:1000131",
+            //            unitCvRef = "MS",
+            //            unitName = "number of detector counts"
+            //        });
+            //    }
+            //}
 
             precursor.selectedIonList.selectedIon[0].cvParam = ionCvParams.ToArray();
 

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -280,6 +280,7 @@ namespace ThermoRawFileParser.Writer
                     name = "Conversion to mzML",
                     value = ""
                 });
+                _writer.WriteEndElement(); // processingMethod  
                 if (!ParseInput.NoPeakPicking)
                 {
                     _writer.WriteStartElement("processingMethod");

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -2184,7 +2184,6 @@ namespace ThermoRawFileParser.Writer
 
             var scanType = new ScanType
             {
-                instrumentConfigurationRef = "null",
                 cvParam = scanTypeCvParams.ToArray()
             };
 

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -119,7 +119,7 @@ namespace ThermoRawFileParser.Writer
                     URI = @"https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo",
                     fullName = "Mass spectrometry ontology",
                     id = "MS",
-                    version = "4.1.12"
+                    version = "4.1.38"
                 });
                 Serialize(serializer, new CVType
                 {

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -1683,16 +1683,19 @@ namespace ThermoRawFileParser.Writer
             if (selectedIonMz > ZeroDelta)
             {
                 var selectedIonIntensity = CalculatePrecursorPeakIntensity(_rawFile, precursorScanNumber, selectedIonMz);
-                ionCvParams.Add(new CVParamType
+                if (selectedIonIntensity != null)
                 {
-                    name = "peak intensity",
-                    value = selectedIonIntensity.ToString(),
-                    accession = "MS:1000042",
-                    cvRef = "MS",
-                    unitAccession = "MS:1000131",
-                    unitCvRef = "MS",
-                    unitName = "number of detector counts"
-                });
+                    ionCvParams.Add(new CVParamType
+                    {
+                        name = "peak intensity",
+                        value = selectedIonIntensity.ToString(),
+                        accession = "MS:1000042",
+                        cvRef = "MS",
+                        unitAccession = "MS:1000131",
+                        unitCvRef = "MS",
+                        unitName = "number of detector counts"
+                    });
+                }
             }
 
             precursor.selectedIonList.selectedIon[0].cvParam = ionCvParams.ToArray();

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -119,7 +119,7 @@ namespace ThermoRawFileParser.Writer
                     URI = @"https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo",
                     fullName = "Mass spectrometry ontology",
                     id = "MS",
-                    version = "4.1.38"
+                    version = "4.1.41"
                 });
                 Serialize(serializer, new CVType
                 {

--- a/Writer/OntologyMapping.cs
+++ b/Writer/OntologyMapping.cs
@@ -228,6 +228,15 @@ namespace ThermoRawFileParser.Writer
                     }
                 },
                 {
+                    "LTQ ORBITRAP CLASSIC", new CVParamType
+                    {
+                        accession = "MS:1002835",
+                        name = "LTQ Orbitrap Classic",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
                     "LTQ ORBITRAP DISCOVERY", new CVParamType
                     {
                         accession = "MS:1000555",
@@ -273,7 +282,43 @@ namespace ThermoRawFileParser.Writer
                     }
                 },
                 {
+                    "ORBITRAP VELOS", new CVParamType
+                    {
+                        accession = "MS:1001742",
+                        name = "LTQ Orbitrap Velos",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
+                    "LTQ ORBITRAP VELOS PRO", new CVParamType
+                    {
+                        accession = "MS:1003096",
+                        name = "LTQ Orbitrap Velos Pro",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
+                    "ORBITRAP VELOS PRO", new CVParamType
+                    {
+                        accession = "MS:1003096",
+                        name = "LTQ Orbitrap Velos Pro",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
                     "LTQ ORBITRAP ELITE", new CVParamType
+                    {
+                        accession = "MS:1001910",
+                        name = "LTQ Orbitrap Elite",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
+                    "ORBITRAP ELITE", new CVParamType
                     {
                         accession = "MS:1001910",
                         name = "LTQ Orbitrap Elite",
@@ -295,6 +340,15 @@ namespace ThermoRawFileParser.Writer
                     {
                         accession = "MS:1000450",
                         name = "LXQ",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
+                    "LTQ XL", new CVParamType
+                    {
+                        accession = "MS:1000854",
+                        name = "LTQ XL",
                         cvRef = "MS",
                         value = ""
                     }
@@ -327,6 +381,15 @@ namespace ThermoRawFileParser.Writer
                     }
                 },
                 {
+                    "LTQ VELOS ETD", new CVParamType
+                    {
+                        accession = "MS:1000856",
+                        name = "LTQ Velos ETD",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
                     "ORBITRAP FUSION", new CVParamType
                     {
                         accession = "MS:1002416",
@@ -354,6 +417,33 @@ namespace ThermoRawFileParser.Writer
                     }
                 },
                 {
+                    "ORBITRAP ECLIPSE", new CVParamType
+                    {
+                        accession = "MS:1003029",
+                        name = "Orbitrap Eclipse",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
+                    "ORBITRAP EXPLORIS 120", new CVParamType
+                    {
+                        accession = "MS:1003095",
+                        name = "Orbitrap Exploris 120",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                                {
+                    "ORBITRAP EXPLORIS 240", new CVParamType
+                    {
+                        accession = "MS:1003094",
+                        name = "Orbitrap Exploris 240",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
                     "ORBITRAP EXPLORIS 480", new CVParamType
                     {
                         accession = "MS:1003028",
@@ -367,6 +457,15 @@ namespace ThermoRawFileParser.Writer
                     {
                         accession = "MS:1000649",
                         name = "Exactive",
+                        cvRef = "MS",
+                        value = ""
+                    }
+                },
+                {
+                    "EXACTIVE PLUS", new CVParamType
+                    {
+                        accession = "MS:1002526",
+                        name = "Exactive Plus",
                         cvRef = "MS",
                         value = ""
                     }
@@ -392,8 +491,8 @@ namespace ThermoRawFileParser.Writer
                 {
                     "Q EXACTIVE PLUS ORBITRAP", new CVParamType
                     {
-                        accession = "MS:1001911",
-                        name = "Q Exactive",
+                        accession = "MS:1002634",
+                        name = "Q Exactive Plus",
                         cvRef = "MS",
                         value = ""
                     }
@@ -435,13 +534,14 @@ namespace ThermoRawFileParser.Writer
         public static CVParamType getInstrumentModel(string instrumentName)
         {
             CVParamType instrumentModel;
+            instrumentName = instrumentName.ToUpper();
             if (OntologyMapping.InstrumentModels.ContainsKey(instrumentName))
             {
-                instrumentModel = OntologyMapping.InstrumentModels[instrumentName.ToUpper()];
+                instrumentModel = OntologyMapping.InstrumentModels[instrumentName];
             }
             else
             {
-                var longestMatch = InstrumentModels.Where(pair => instrumentName.ToUpper().Contains(pair.Key))
+                var longestMatch = InstrumentModels.Where(pair => instrumentName.Contains(pair.Key))
                     .Select(pair => pair.Key)
                     .Aggregate("", (max, current) => max.Length > current.Length ? max : current);
                 if (!longestMatch.IsNullOrEmpty())
@@ -477,8 +577,10 @@ namespace ThermoRawFileParser.Writer
                 case "MS:1000448":
                 // LTQ FT ULTRA    
                 case "MS:1000557":
-                // LTQ ORBITRAP    
+                // LTQ ORBITRAP 
                 case "MS:1000449":
+                // LTQ ORBITRAP CLASSIC
+                case "MS:1002835":
                 // LTQ ORBITRAP DISCOVERY   
                 case "MS:1000555":
                 // LTQ ORBITRAP XL   
@@ -489,6 +591,8 @@ namespace ThermoRawFileParser.Writer
                 case "MS:1000643":
                 // LTQ ORBITRAP VELOS    
                 case "MS:1001742":
+                // LTQ ORBITRAP VELOS PRO
+                case "MS:1003096":
                 // LTQ ORBITRAP ELITE    
                 case "MS:1001910":
                 // ORBITRAP FUSION
@@ -497,7 +601,13 @@ namespace ThermoRawFileParser.Writer
                 case "MS:1002417":
                 // ORBITRAP FUSION LUMOS
                 case "MS:1002732":
-                // ORBITRAP EXPLORIS 480    
+                // ORBITRAP ECLIPSE    
+                case "MS:1003029":
+                // ORBITRAP EXPLORIS 120
+                case "MS:1003095":
+                // ORBITRAP EXPLORIS 240
+                case "MS:1003094":
+                // ORBITRAP EXPLORIS 480
                 case "MS:1003028":
                     detectors = new List<CVParamType>
                     {
@@ -519,6 +629,8 @@ namespace ThermoRawFileParser.Writer
                     break;
                 // EXACTIVE
                 case "MS:1000649":
+                // EXACTIVE PLUS
+                case "MS:1002526":
                 // Q EXACTIVE
                 case "MS:1001911":
                 // Q EXACTIVE HF    
@@ -540,9 +652,15 @@ namespace ThermoRawFileParser.Writer
                     break;
                 // LTQ
                 case "MS:1000447":
+                // LTQ VELOS
+                case "MS:1000855":
+                // LTQ VELOS ETD
+                case "MS:1000856":
                 // LXQ    
                 case "MS:1000450":
-                // LTQ XL ETD    
+                // LTQ XL
+                case "MS:1000854":
+                // LTQ XL ETD
                 case "MS:1000638":
                 // MALDI LTQ XL    
                 case "MS:1000642":

--- a/Writer/OntologyMapping.cs
+++ b/Writer/OntologyMapping.cs
@@ -523,6 +523,15 @@ namespace ThermoRawFileParser.Writer
                         cvRef = "MS",
                         value = ""
                     }
+                },
+                {
+                    "ORBITRAP ID-X", new CVParamType
+                    {
+                        accession = "MS:1003112",
+                        name = "Orbitrap ID-X",
+                        cvRef = "MS",
+                        value = ""
+                    }
                 }
             };
 

--- a/Writer/SpectrumWriter.cs
+++ b/Writer/SpectrumWriter.cs
@@ -178,6 +178,7 @@ namespace ThermoRawFileParser.Writer
             double precursorMass)
         {
             double? precursorIntensity = null;
+            double tolerance;
 
             // Get the precursor scan from the RAW file
             var scan = Scan.FromFile(rawFile, precursorScanNumber);
@@ -190,15 +191,17 @@ namespace ThermoRawFileParser.Writer
             {
                 masses = scan.CentroidScan.Masses;
                 intensities = scan.CentroidScan.Intensities;
+                tolerance = 0.01; //high resolution scan
             }
             else
             {
                 masses = scan.SegmentedScan.Positions;
                 intensities = scan.SegmentedScan.Intensities;
+                tolerance = 0.5; //low resolution scan
             }
 
             //find closest peak in a stream
-            var bestDelta = Tolerance;
+            var bestDelta = tolerance;
             for (var i = 0; i < masses.Length; i++)
             {
                 var delta = precursorMass - masses[i];
@@ -208,7 +211,7 @@ namespace ThermoRawFileParser.Writer
                     precursorIntensity = intensities[i];
                 }
 
-                if (delta < -1 * Tolerance) break;
+                if (delta < -1 * tolerance) break;
             }
 
             return precursorIntensity;

--- a/Writer/SpectrumWriter.cs
+++ b/Writer/SpectrumWriter.cs
@@ -97,9 +97,9 @@ namespace ThermoRawFileParser.Writer
         /// Construct the spectrum title.
         /// </summary>
         /// <param name="scanNumber">the spectrum scan number</param>
-        protected static string ConstructSpectrumTitle(int scanNumber)
+        protected static string ConstructSpectrumTitle(int instrumentType, int instrumentNumber, int scanNumber)
         {
-            return "controllerType=0 controllerNumber=1 scan=" + scanNumber;
+            return String.Format("controllerType={0} controllerNumber={1} scan={2}", instrumentType, instrumentNumber, scanNumber);
         }
 
         /// <summary>


### PR DESCRIPTION
Changes include
+ Able to extract additional detector data - UV, PDA, pressure chromatograms, PDA spectra (new key -a --allDetectors)
+ Fix instrument mapping, adding new instruments (Explorises, ID-X etc)

* Update ontology version
* Fix bug when output directory is empty

> precursor ion intensity function is rewritten but disabled (does not match msconvert)
