### PR TITLE
Catch ObjectDisposedException when closing the wrapped cryptoStream.

### DIFF
--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -587,8 +587,16 @@ namespace ThermoRawFileParser.Writer
 
                 if (_doIndexing)
                 {
-                    cryptoStream.Flush();
-                    cryptoStream.Close();
+                    try
+                    {
+                        cryptoStream.Flush();
+                        cryptoStream.Close();
+                    }
+                    catch (System.ObjectDisposedException e)
+                    {
+                        // Cannot access a closed file.  CryptoStream was already closed when closing _writer
+                        Log.Warn($"Warning: {e.Message}");
+                    }
                 }
             }
 


### PR DESCRIPTION
In cryptoStream.Close(), a System.ObjectDisposedException ("Cannot access a closed file.") is raised. Observed on Windows 2019 Server.

Based on the XmlWriter documentation (the wrapping stream), closing CryptoStream explicitly should not be required. We changed the code to catch the exception because we do not understand your design intent when making this close explicit. We believe that both Flush() and Close() should be removed. 