### PR TITLE
mzParquet writer v0.2 full implementation

### DIFF
--- a/MainClass.cs
+++ b/MainClass.cs
@@ -768,6 +768,9 @@ namespace ThermoRawFileParser
                     if (parseInput.OutputFormat == OutputFormat.IndexMzML) parseInput.OutputFormat = OutputFormat.MzML;
                 }
 
+                // Switch off gzip compression for Parquet
+                if (parseInput.OutputFormat == OutputFormat.Parquet) parseInput.Gzip = false;
+
                 parseInput.MaxLevel = parseInput.MsLevel.Max();
 
                 if (parseInput.S3Url != null && parseInput.S3AccessKeyId != null &&

--- a/ThermoRawFileParserTest/ThermoRawFileParserTest.csproj
+++ b/ThermoRawFileParserTest/ThermoRawFileParserTest.csproj
@@ -32,6 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Parquet.Net" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThermoRawFileParserTest/WriterTests.cs
+++ b/ThermoRawFileParserTest/WriterTests.cs
@@ -281,5 +281,30 @@ namespace ThermoRawFileParserTest
 
             Assert.That(testMzMl.run.chromatogramList.chromatogram[0].defaultArrayLength, Is.EqualTo(95));
         }
+
+        [Test]
+        public void TestParquet()
+        {
+            // Get temp path for writing the test mzML
+            var tempFilePath = Path.GetTempPath();
+
+            var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Data/small.RAW");
+            var parseInput = new ParseInput(testRawFile, null, tempFilePath, OutputFormat.Parquet);
+
+            RawFileParser.Parse(parseInput);
+
+            // Actual test
+            //var xmlSerializer = new XmlSerializer(typeof(mzMLType));
+            //var testMzMl = (mzMLType)xmlSerializer.Deserialize(new FileStream(
+            //    Path.Combine(tempFilePath, "small.mzML"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+
+            //Assert.That(testMzMl.run.spectrumList.count, Is.EqualTo("48"));
+            //Assert.That(testMzMl.run.spectrumList.spectrum.Length, Is.EqualTo(48));
+
+            //Assert.That(testMzMl.run.chromatogramList.count, Is.EqualTo("1"));
+            //Assert.That(testMzMl.run.chromatogramList.chromatogram.Length, Is.EqualTo(1));
+
+            //Assert.That(testMzMl.run.chromatogramList.chromatogram[0].defaultArrayLength, Is.EqualTo(48));
+        }
     }
 }

--- a/ThermoRawFileParserTest/WriterTests.cs
+++ b/ThermoRawFileParserTest/WriterTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Xml.Serialization;
 using IO.Mgf;
 using NUnit.Framework;
+using Parquet;
 using ThermoRawFileParser;
 using ThermoRawFileParser.Writer.MzML;
 
@@ -283,7 +284,7 @@ namespace ThermoRawFileParserTest
         }
 
         [Test]
-        public void TestParquet()
+        public void TestParquetCentroid()
         {
             // Get temp path for writing the test mzML
             var tempFilePath = Path.GetTempPath();
@@ -294,17 +295,45 @@ namespace ThermoRawFileParserTest
             RawFileParser.Parse(parseInput);
 
             // Actual test
-            //var xmlSerializer = new XmlSerializer(typeof(mzMLType));
-            //var testMzMl = (mzMLType)xmlSerializer.Deserialize(new FileStream(
-            //    Path.Combine(tempFilePath, "small.mzML"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+            var parquetFilePath = Path.Combine(tempFilePath, "small.mzparquet");
 
-            //Assert.That(testMzMl.run.spectrumList.count, Is.EqualTo("48"));
-            //Assert.That(testMzMl.run.spectrumList.spectrum.Length, Is.EqualTo(48));
+            using (var parquetReader = ParquetReader.CreateAsync(parquetFilePath).Result)
+            {
+                var groupReader = parquetReader.OpenRowGroupReader(0);
+                var schema = parquetReader.Schema;
+                var scanColumn = groupReader.ReadColumnAsync(schema.FindDataField("scan")).Result;
 
-            //Assert.That(testMzMl.run.chromatogramList.count, Is.EqualTo("1"));
-            //Assert.That(testMzMl.run.chromatogramList.chromatogram.Length, Is.EqualTo(1));
+                Assert.That(scanColumn.NumValues, Is.EqualTo(48520));
+                Assert.That(scanColumn.Statistics.DistinctCount, Is.EqualTo(48));
+                Assert.That((from int p in scanColumn.Data where p == 22 select p).Count(), Is.EqualTo(1632));
+            }
+        }
 
-            //Assert.That(testMzMl.run.chromatogramList.chromatogram[0].defaultArrayLength, Is.EqualTo(48));
+        [Test]
+        public void TestParquetProfile()
+        {
+            // Get temp path for writing the test mzML
+            var tempFilePath = Path.GetTempPath();
+
+            var testRawFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"Data/small.RAW");
+            var parseInput = new ParseInput(testRawFile, null, tempFilePath, OutputFormat.Parquet);
+            parseInput.NoPeakPicking = new HashSet<int> { 1, 2 };
+
+            RawFileParser.Parse(parseInput);
+
+            // Actual test
+            var parquetFilePath = Path.Combine(tempFilePath, "small.mzparquet");
+
+            using (var parquetReader = ParquetReader.CreateAsync(parquetFilePath).Result)
+            {
+                var groupReader = parquetReader.OpenRowGroupReader(0);
+                var schema = parquetReader.Schema;
+                var scanColumn = groupReader.ReadColumnAsync(schema.FindDataField("scan")).Result;
+
+                Assert.That(scanColumn.NumValues, Is.EqualTo(305213));
+                Assert.That(scanColumn.Statistics.DistinctCount, Is.EqualTo(48));
+                Assert.That((from int p in scanColumn.Data where p == 22 select p).Count(), Is.EqualTo(17758));
+            }
         }
     }
 }

--- a/Writer/MgfSpectrumWriter.cs
+++ b/Writer/MgfSpectrumWriter.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using log4net;
 using ThermoFisher.CommonCore.Data.Business;
 using ThermoFisher.CommonCore.Data.FilterEnums;
@@ -19,14 +16,8 @@ namespace ThermoRawFileParser.Writer
         private const string PositivePolarity = "+";
         private const string NegativePolarity = "-";
 
-        // Filter string
-        private readonly Regex _filterStringIsolationMzPattern = new Regex(@"ms\d+ (.+?) \[");
-
         // Precursor scan number for MSn scans
         private int _precursorScanNumber;
-
-        // Precursor scan number (value) and isolation m/z (key) for reference in the precursor element of an MSn spectrum
-        private readonly Dictionary<string, int> _precursorScanNumbers = new Dictionary<string, int>();
 
         public MgfSpectrumWriter(ParseInput parseInput) : base(parseInput)
         {
@@ -126,23 +117,7 @@ namespace ThermoRawFileParser.Writer
                             }
                             else //try getting it from the scan filter
                             {
-                                var parts = Regex.Split(result.Groups[1].Value, " ");
-
-                                //find the position of the first (from the end) precursor with a different mass 
-                                //to account for possible supplementary activations written in the filter
-                                var lastIonMass = parts.Last().Split('@').First();
-                                int last = parts.Length;
-                                while (last > 0 &&
-                                       parts[last - 1].Split('@').First() == lastIonMass)
-                                {
-                                    last--;
-                                }
-
-                                string parentFilter = String.Join(" ", parts.Take(last));
-                                if (_precursorScanNumbers.ContainsKey(parentFilter))
-                                {
-                                    _precursorScanNumber = _precursorScanNumbers[parentFilter];
-                                }
+                                _precursorScanNumber = GetParentFromScanString(result.Groups[1].Value);
                             }
 
                             if (_precursorScanNumber > 0)
@@ -151,7 +126,8 @@ namespace ThermoRawFileParser.Writer
                             }
                             else
                             {
-                                Log.Error($"Failed finding precursor for {scanNumber}");
+                                Log.Error($"Cannot find precursor scan for scan# {scanNumber}");
+                                _precursorTree[-2] = new PrecursorInfo(0, msLevel, FindLastReaction(scanEvent, msLevel), null);
                                 ParseInput.NewError();
                             }
                         }

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -1286,7 +1286,7 @@ namespace ThermoRawFileParser.Writer
             int? charge = trailerData.AsPositiveInt("Charge State:");
             double? monoisotopicMz = trailerData.AsDouble("Monoisotopic M/Z:");
             double? ionInjectionTime = trailerData.AsDouble("Ion Injection Time (ms):");
-            double? isolationWidth = trailerData.AsDouble("MS" + (int) scanFilter.MSOrder + " Isolation Width:");
+            double? isolationWidth = trailerData.AsDouble("MS" + msLevel + " Isolation Width:");
             double? FAIMSCV = null;
             if (trailerData.AsBool("FAIMS Voltage On:").GetValueOrDefault(false))
                 FAIMSCV = trailerData.AsDouble("FAIMS CV:");

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -641,21 +641,6 @@ namespace ThermoRawFileParser.Writer
 
                 Writer.Flush();
                 Writer.Close();
-
-                //This section is not necessary?
-                /*if (_doIndexing)
-                {
-                    try
-                    {
-                        cryptoStream.Flush();
-                        cryptoStream.Close();
-                    }
-                    catch (System.ObjectDisposedException e)
-                    {
-                        // Cannot access a closed file.  CryptoStream was already closed when closing _writer
-                        Log.Warn($"Warning: {e.Message}");
-                    }
-                }*/
             }
 
             // In case of indexed mzML, change the extension from xml to mzML and check for the gzip option

--- a/Writer/MzMlSpectrumWriter.cs
+++ b/Writer/MzMlSpectrumWriter.cs
@@ -27,8 +27,6 @@ namespace ThermoRawFileParser.Writer
         private static readonly ILog Log =
             LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        private readonly Regex _filterStringIsolationMzPattern = new Regex(@"ms\d+ (.+?) \[");
-
         // Tune version < 3 produces multiple trailer entry like "SPS Mass [number]"
         private readonly Regex _spSentry = new Regex(@"SPS Mass\s+\d+:");
 
@@ -44,12 +42,6 @@ namespace ThermoRawFileParser.Writer
         // Dictionary to keep track of the different ionization modes (key: Thermo IonizationModeType; value: the reference string)
         private readonly Dictionary<IonizationModeType, CVParamType> _ionizationTypes =
             new Dictionary<IonizationModeType, CVParamType>();
-
-        // Precursor scan number (value) and isolation m/z (key) for reference in the precursor element of an MSn spectrum
-        private readonly Dictionary<string, int> _precursorScanNumbers = new Dictionary<string, int>();
-
-        //Precursor information for scans
-        private Dictionary<int, PrecursorInfo> _precursorTree = new Dictionary<int, PrecursorInfo>();
 
         private const string SourceFileId = "RAW1";
         private readonly XmlSerializerFactory _factory = new XmlSerializerFactory();
@@ -68,8 +60,6 @@ namespace ThermoRawFileParser.Writer
             _mzMlNamespace.Add(string.Empty, "http://psi.hupo.org/ms/mzml");
             _doIndexing = ParseInput.OutputFormat == OutputFormat.IndexMzML;
             _osOffset = Environment.NewLine == "\n" ? 0 : 1;
-            _precursorScanNumbers[""] = -1;
-            _precursorTree[-1] = new PrecursorInfo();
         }
 
         /// <inheritdoc />
@@ -639,7 +629,6 @@ namespace ThermoRawFileParser.Writer
 
                     _writer.WriteValue(BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant());
                     _writer.WriteEndElement(); // fileChecksum
-
                     _writer.WriteEndElement(); // indexedmzML                                           
                 }
 
@@ -1374,6 +1363,7 @@ namespace ThermoRawFileParser.Writer
                 {
                     Log.Warn($"Cannot find precursor scan for scan# {scanNumber}");
                     _precursorTree[-2] = new PrecursorInfo(0, msLevel, FindLastReaction(scanEvent, msLevel), new PrecursorType[0]);
+                    ParseInput.NewWarn();
                 }
 
                 try
@@ -1938,46 +1928,6 @@ namespace ThermoRawFileParser.Writer
 
             return spectrum;
         }
-
-        private int FindLastReaction(IScanEvent scanEvent, int msLevel)
-        {
-            int lastReactionIndex = msLevel - 2;
-
-            //iteratively trying find the last available index for reaction
-            while(true)
-            {
-                try
-                {
-                    scanEvent.GetReaction(lastReactionIndex + 1);
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    //stop trying
-                    break;
-                }
-
-                lastReactionIndex++;
-            }
-
-            //supplemental activation flag is on -> one of the levels (not necissirily the last one) used supplemental activation
-            //check last two activations
-            if (scanEvent.SupplementalActivation == TriState.On) 
-            {
-                var lastActivation = scanEvent.GetReaction(lastReactionIndex).ActivationType;
-                var beforeLastActivation = scanEvent.GetReaction(lastReactionIndex - 1).ActivationType;
-
-                if ((beforeLastActivation == ActivationType.ElectronTransferDissociation || beforeLastActivation == ActivationType.ElectronCaptureDissociation) &&
-                    (lastActivation == ActivationType.CollisionInducedDissociation || lastActivation == ActivationType.HigherEnergyCollisionalDissociation))
-                    return lastReactionIndex - 1; //ETD or ECD followed by HCD or CID -> supplemental activation in the last level (move the last reaction one step back)
-                else
-                    return lastReactionIndex;
-            }
-            else //just use the last one
-            {
-                return lastReactionIndex;
-            }
-        }
-
         private SpectrumType ConstructPDASpectrum(int scanNumber, int instrumentNumber)
         {
             // Get each scan from the RAW file
@@ -2556,29 +2506,6 @@ namespace ThermoRawFileParser.Writer
                 precursor = precursors.ToArray()
             };
 
-        }
-
-        private int GetParentFromScanString(string scanString)
-        {
-            var parts = Regex.Split(scanString, " ");
-
-            //find the position of the first (from the end) precursor with a different mass 
-            //to account for possible supplementary activations written in the filter
-            var lastIonMass = parts.Last().Split('@').First();
-            int last = parts.Length;
-            while (last > 0 &&
-                   parts[last - 1].Split('@').First() == lastIonMass)
-            {
-                last--;
-            }
-
-            string parentFilter = String.Join(" ", parts.Take(last));
-            if (_precursorScanNumbers.ContainsKey(parentFilter))
-            {
-                return _precursorScanNumbers[parentFilter];
-            }
-
-            return -2; //unsuccessful parsing
         }
 
         /// <summary>

--- a/Writer/ParquetSpectrumWriter.cs
+++ b/Writer/ParquetSpectrumWriter.cs
@@ -1,257 +1,192 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using log4net;
-using Parquet;
-using Parquet.Data;
+using Parquet.Serialization;
 using ThermoFisher.CommonCore.Data;
 using ThermoFisher.CommonCore.Data.Business;
 using ThermoFisher.CommonCore.Data.FilterEnums;
 using ThermoFisher.CommonCore.Data.Interfaces;
-using ThermoRawFileParser.Writer.MzML;
 
 namespace ThermoRawFileParser.Writer
 {
+
+    struct MzParquet
+    {
+        public uint scan;
+        public uint level;
+        public float rt;
+        public float mz;
+        public float intensity;
+        public float? ion_mobility;
+        public float? isolation_lower;
+        public float? isolation_upper;
+        public uint? precursor_scan;
+        public float? precursor_mz;
+        public uint? precursor_charge;
+    }
+
     public class ParquetSpectrumWriter : SpectrumWriter
     {
         private static readonly ILog Log =
             LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        private IRawDataPlus _rawFile;
-
-        // Dictionary to keep track of the different mass analyzers (key: Thermo MassAnalyzerType; value: the reference string)       
-        private readonly Dictionary<MassAnalyzerType, string> _massAnalyzers =
-            new Dictionary<MassAnalyzerType, string>();
-
-        private readonly Dictionary<IonizationModeType, CVParamType> _ionizationTypes =
-            new Dictionary<IonizationModeType, CVParamType>();
-
         public ParquetSpectrumWriter(ParseInput parseInput) : base(parseInput)
         {
         }
 
-        public override void Write(IRawDataPlus rawFile, int firstScanNumber, int lastScanNumber)
+        public override void Write(IRawDataPlus raw, int firstScanNumber, int lastScanNumber)
         {
-            _rawFile = rawFile;
-            if (rawFile.HasMsData)
-            {
-                List<PScan> pScans = new List<PScan>();
-                WritePScans(ParseInput.OutputDirectory, rawFile.FileName, rawFile, pScans);
-            }
-            else
+            if (!raw.HasMsData)
             {
                 throw new RawFileParserException("No MS data in RAW file, no output will be produced");
             }
-        }
 
-        private static void WritePScans(string outputDirectory, string fileName,
-            IRawDataPlus raw,
-            List<PScan> scans)
-        {
             var enumerator = raw.GetFilteredScanEnumerator(" ");
 
-            foreach (var scanNumber in enumerator
-            ) // note in my tests serial is faster than Parallel.Foreach() (this involves disk access, so it makes sense)
-            {
-                //trailer information is extracted via index
-                var trailers = raw.GetTrailerExtraValues(scanNumber);
-                var trailerLabels = raw.GetTrailerExtraInformation(scanNumber);
-                object chargeState = 0;
-                for (int i = 0; i < trailerLabels.Labels.Length; i++)
-                {
-                    if (trailerLabels.Labels[i] == "Charge State:")
-                    {
-                        chargeState = raw.GetTrailerExtraValue(scanNumber, i);
-                        break;
-                    }
-                }
+            // NB: replace with more robust strategy?
+            var output = ParseInput.OutputDirectory + "//" + Path.GetFileNameWithoutExtension(ParseInput.RawFilePath) + ".mzparquet";
 
+            ParquetSerializerOptions opts = new ParquetSerializerOptions();
+            opts.CompressionLevel = System.IO.Compression.CompressionLevel.Fastest;
+            opts.CompressionMethod = Parquet.CompressionMethod.Zstd;
+
+            var data = new List<MzParquet>();
+
+            // map last (msOrder - 1) -> scan number (e.g. mapping precursors)
+            // note, this assumes time dependence of MS1 -> MS2 -> MSN
+            var last_scans = new Dictionary<int, uint>();
+
+
+            foreach (var scanNumber in enumerator) 
+            {
                 var scanFilter = raw.GetFilterForScanNumber(scanNumber);
-                var scanStats = raw.GetScanStatsForScanNumber(scanNumber);
 
                 CentroidStream centroidStream = new CentroidStream();
 
-                //check for FT mass analyzer data
+                // Pull out m/z and intensity values
+                // NB: is this the best way to do this?
                 if (scanFilter.MassAnalyzer == MassAnalyzerType.MassAnalyzerFTMS)
                 {
                     centroidStream = raw.GetCentroidStream(scanNumber, false);
                 }
-
-                //check for IT mass analyzer data
-                if (scanFilter.MassAnalyzer == MassAnalyzerType.MassAnalyzerITMS)
+                else if (scanFilter.MassAnalyzer == MassAnalyzerType.MassAnalyzerITMS)
                 {
                     var scanData = raw.GetSimplifiedScan(scanNumber);
                     centroidStream.Masses = scanData.Masses;
                     centroidStream.Intensities = scanData.Intensities;
                 }
+                else
+                {
+                    var scanData = raw.GetSimplifiedCentroids(scanNumber);
+                    centroidStream.Masses = scanData.Masses;
+                    centroidStream.Intensities = scanData.Intensities;
+                }
+
 
                 var msOrder = raw.GetScanEventForScanNumber(scanNumber).MSOrder;
 
-                if (msOrder == MSOrderType.Ms)
+                last_scans[(int)msOrder] = (uint)scanNumber;
+
+                double rt = raw.RetentionTimeFromScanNumber(scanNumber);
+                float? isolation_lower = null;
+                float? isolation_upper = null;
+                uint? precursor_scan = null;
+                float? precursor_mz = null;
+                uint? precursor_charge = null;
+
+                if ((int)msOrder > 1)
                 {
-                    var pscan = GetPScan(scanStats, centroidStream, fileName, Convert.ToInt32(chargeState));
-                    scans.Add(pscan);
+                    var rx = scanFilter.GetReaction(0);
+
+                    // this assumes symmetrical quad window
+                    isolation_lower = (float)(rx.PrecursorMass - rx.IsolationWidth / 2);
+                    isolation_upper = (float)(rx.PrecursorMass + rx.IsolationWidth / 2);
+                    precursor_mz = (float)rx.PrecursorMass;
+
+                    // Try to retrieve last scan that occurred at the previous msOrder
+                    uint t;
+                    if (last_scans.TryGetValue((int)msOrder - 1, out t))
+                    {
+                        precursor_scan = t;
+                    }
                 }
 
-                if (msOrder == MSOrderType.Ms2)
+                var trailer = raw.GetTrailerExtraInformation(scanNumber);
+                for (var i = 0l; i < trailer.Length; i++)
                 {
-                    var precursorMz = raw.GetScanEventForScanNumber(scanNumber).GetReaction(0).PrecursorMass;
-                    var pscan = GetPScan(scanStats, centroidStream, fileName, precursorMz,
-                        Convert.ToInt32(chargeState));
-                    scans.Add(pscan);
+
+                    if (trailer.Labels[i].StartsWith("Monoisotopic M/Z"))
+                    {
+                        var val = float.Parse(trailer.Values[i]);
+                        if (val > 0)
+                        {
+                            precursor_mz = val;
+                        }
+                    }
+
+                    // Overwrite precursor_scan with value from trailer, if it exists
+                    if (trailer.Labels[i].StartsWith("Master Scan"))
+                    {
+                        var val = Int64.Parse(trailer.Values[i]);
+                        if (val > 0)
+                        {
+                            precursor_scan = (uint)val;
+                        }
+                    }
+
+                    if (trailer.Labels[i].StartsWith("Charge"))
+                    {
+                        var val = uint.Parse(trailer.Values[i]);
+                        if (val > 0)
+                        {
+                            precursor_charge = val;
+                        }
+                    }
                 }
 
-                var t = raw.GetTrailerExtraValues(scanNumber);
+                // Add a row to parquet file for every m/z value in this scan
+                for (int i = 0; i < centroidStream.Masses.Length; i++)
+                {
+                    MzParquet m;
+                    m.rt = (float)rt;
+                    m.scan = (uint)scanNumber;
+                    m.level = ((uint)msOrder);
+                    m.intensity = (float)centroidStream.Intensities[i];
+                    m.mz = (float)centroidStream.Masses[i];
+                    m.isolation_lower = isolation_lower;
+                    m.isolation_upper = isolation_upper;
+                    m.precursor_scan = precursor_scan;
+                    m.precursor_mz = precursor_mz;
+                    m.precursor_charge = precursor_charge;
+                    m.ion_mobility = null;
+                    data.Add(m);
+                }
+
+                // If we have enough ions to write a row group, do so
+                // - some row groups might have more than this number of ions
+                //   but this ensures that all ions from a single scan are always
+                //   present in the same row group (critical property of mzparquet)
+                if (data.Count >= 1_048_576)
+                {
+                    var task = ParquetSerializer.SerializeAsync(data, output, opts);
+                    task.Wait();
+                    opts.Append = true;
+                    data.Clear();
+                    Log.Info("writing row group");
+                }
+
             }
 
-            WriteScans(outputDirectory, scans, fileName);
-        }
-
-        private static PScan GetPScan(ScanStatistics scanStats, CentroidStream centroidStream,
-            string fileName, double? precursorMz = null, int? precursorCharge = null)
-        {
-            var scan = new PScan
+            // serialize any remaining ions into the final row group
+            if (data.Count > 0)
             {
-                FileName = fileName,
-                BasePeakMass = scanStats.BasePeakMass,
-                ScanType = scanStats.ScanType,
-                BasePeakIntensity = scanStats.BasePeakIntensity,
-                PacketType = scanStats.PacketType,
-                ScanNumber = scanStats.ScanNumber,
-                RetentionTime = scanStats.StartTime,
-                Masses = centroidStream.Masses.ToArray(),
-                Intensities = centroidStream.Intensities.ToArray(),
-                LowMass = scanStats.LowMass,
-                HighMass = scanStats.HighMass,
-                TIC = scanStats.TIC,
-                FileId = fileName,
-                PrecursorMz = precursorMz,
-                PrecursorCharge = precursorCharge,
-                MsOrder = 1
-            };
-            return scan;
-        }
-
-        public static void WriteScans(string outputDirectory, List<PScan> scans, string sourceRawFileName)
-        {
-            throw new NotImplementedException();
-
-            //Needs refactoring since Parquet.NET API changed
-        
-            //var output = outputDirectory + "//" + Path.GetFileNameWithoutExtension(sourceRawFileName);
-
-            //var ds = new DataSet(new DataField<double>("BasePeakIntensity"),
-            //    new DataField<double>("BasePeakMass"),
-            //    new DataField<double[]>("Baselines"),
-            //    new DataField<double[]>("Charges"),
-            //    new DataField<string>("FileId"),
-            //    new DataField<string>("FileName"),
-            //    new DataField<double>("HighMass"),
-            //    new DataField<double[]>("Intensities"),
-            //    new DataField<double>("LowMass"),
-            //    new DataField<double[]>("Masses"),
-            //    new DataField<int>("MsOrder"),
-            //    new DataField<double[]>("Noises"),
-            //    new DataField<int>("PacketType"),
-            //    new DataField<int?>("PrecursorCharge"),
-            //    new DataField<double?>("PrecursorMass"),
-            //    new DataField<double[]>("Resolutions"),
-            //    new DataField<double>("RetentionTime"),
-            //    new DataField<int>("ScanNumber"),
-            //    new DataField<string>("ScanType"),
-            //    new DataField<double>("TIC"));
-
-            //foreach (var scan in scans)
-            //{
-            //    //we can't store null values?
-            //    double[] dummyVal = new double[1];
-            //    if (scan.Noises == null)
-            //    {
-            //        scan.Noises = dummyVal;
-            //    }
-
-            //    if (scan.Charges == null)
-            //    {
-            //        scan.Charges = dummyVal;
-            //    }
-
-            //    if (scan.Baselines == null)
-            //    {
-            //        scan.Baselines = dummyVal;
-            //    }
-
-            //    if (scan.Resolutions == null)
-            //    {
-            //        scan.Resolutions = dummyVal;
-            //    }
-
-            //    if (scan.PrecursorMz == null)
-            //    {
-            //        scan.PrecursorMz = 0;
-            //        scan.PrecursorCharge = 0;
-            //    }
-
-            //    ds.Add(scan.BasePeakIntensity,
-            //        scan.BasePeakMass,
-            //        scan.Baselines,
-            //        scan.Charges,
-            //        scan.FileId,
-            //        scan.FileName,
-            //        scan.HighMass,
-            //        scan.Intensities,
-            //        scan.LowMass,
-            //        scan.Masses,
-            //        scan.MsOrder,
-            //        scan.Noises,
-            //        scan.PacketType,
-            //        scan.PrecursorCharge,
-            //        scan.PrecursorMz,
-            //        scan.Resolutions,
-            //        scan.RetentionTime,
-            //        scan.ScanNumber,
-            //        scan.ScanType,
-            //        scan.TIC);
-            //}
-
-            //using (Stream fileStream = File.OpenWrite(output + ".parquet"))
-            //{
-            //    using (var writer = new ParquetWriter(fileStream))
-            //    {
-            //        writer.Write(ds);
-            //    }
-            //}
+                var task = ParquetSerializer.SerializeAsync(data, output, opts);
+                task.Wait();
+                Log.Info("writing row group");
+            }
         }
     }
 
-    /// PSCan meaing Parsec Scan (because Commoncore has a Scan class)
-    /// </summary>
-    public class PScan
-    {
-        /// <summary>
-        /// Unique ID per file (foreign key in data store)
-        /// </summary>
-        public string FileId { get; set; }
-
-        public string FileName { get; set; }
-        public double BasePeakIntensity { get; set; }
-        public double BasePeakMass { get; set; }
-        public double[] Baselines { get; set; }
-        public double[] Charges { get; set; }
-        public double HighMass { get; set; }
-        public double[] Intensities { get; set; }
-        public double LowMass { get; set; }
-        public double[] Masses { get; set; }
-        public double[] Noises { get; set; }
-        public int PacketType { get; set; } // : 20,
-        public double RetentionTime { get; set; }
-        public double[] Resolutions { get; set; }
-        public int ScanNumber { get; set; }
-        public string ScanType { get; set; } // : FTMS + c ESI d Full ms2 335.9267@hcd30.00 [130.0000-346.0000],
-        public double TIC { get; set; }
-        public int MsOrder { get; set; }
-        public double? PrecursorMz { get; set; }
-        public int? PrecursorCharge { get; set; }
-    }
 }

--- a/Writer/SpectrumWriter.cs
+++ b/Writer/SpectrumWriter.cs
@@ -68,42 +68,27 @@ namespace ThermoRawFileParser.Writer
                 return;
             }
 
-            if (ParseInput.OutputFile == null)
+            var fileName = NormalizeFileName(ParseInput.OutputFile, extension, ParseInput.Gzip);
+            if (ParseInput.OutputFormat == OutputFormat.Parquet)
             {
-                var fullExtension = ParseInput.Gzip ? extension + ".gz" : extension;
-                if (!ParseInput.Gzip || ParseInput.OutputFormat == OutputFormat.IndexMzML)
-                {
-                    Writer = File.CreateText(ParseInput.OutputDirectory + "//" +
-                                             ParseInput.RawFileNameWithoutExtension +
-                                             extension);
-                }
-                else
-                {
-                    var fileStream = File.Create(ParseInput.OutputDirectory + "//" +
-                                                 ParseInput.RawFileNameWithoutExtension + fullExtension);
-                    var compress = new GZipStream(fileStream, CompressionMode.Compress);
-                    Writer = new StreamWriter(compress);
-                }
+                Writer = new StreamWriter(File.Create(fileName));
+            }
+            else if (!ParseInput.Gzip || ParseInput.OutputFormat == OutputFormat.IndexMzML)
+            {
+                Writer = File.CreateText(fileName);
             }
             else
             {
-                var fileName = NormalizeFileName(ParseInput.OutputFile, extension, ParseInput.Gzip);
-                if (!ParseInput.Gzip || ParseInput.OutputFormat == OutputFormat.IndexMzML)
-                {
-                    Writer = File.CreateText(fileName);
-                }
-                else
-                {
-                    var fileStream = File.Create(fileName);
-                    var compress = new GZipStream(fileStream, CompressionMode.Compress);
-                    Writer = new StreamWriter(compress);
-                }
+                var fileStream = File.Create(fileName);
+                var compress = new GZipStream(fileStream, CompressionMode.Compress);
+                Writer = new StreamWriter(compress);
             }
+            
         }
 
         private string NormalizeFileName(string outputFile, string extension, bool gzip)
         {
-            string result = outputFile;
+            string result = outputFile == null ? Path.Combine(ParseInput.OutputDirectory, ParseInput.RawFileNameWithoutExtension) : outputFile;
             string tail = "";
 
             string[] extensions;

--- a/Writer/SpectrumWriter.cs
+++ b/Writer/SpectrumWriter.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using log4net;
 using ThermoFisher.CommonCore.Data;
 using ThermoFisher.CommonCore.Data.Business;
 using ThermoFisher.CommonCore.Data.FilterEnums;
 using ThermoFisher.CommonCore.Data.Interfaces;
 using ThermoRawFileParser.Util;
+using System.Linq;
 
 namespace ThermoRawFileParser.Writer
 {
@@ -42,6 +45,15 @@ namespace ThermoRawFileParser.Writer
         /// </summary>
         private static LimitedSizeDictionary<int, MZArray> precursorCache;
 
+        // Precursor scan number (value) and isolation m/z (key) for reference in the precursor element of an MSn spectrum
+        private protected readonly Dictionary<string, int> _precursorScanNumbers = new Dictionary<string, int>();
+
+        //Precursor information for scans
+        private protected Dictionary<int, PrecursorInfo> _precursorTree = new Dictionary<int, PrecursorInfo>();
+
+        // Filter string regex to extract an isoaltion entry
+        private protected readonly Regex _filterStringIsolationMzPattern = new Regex(@"ms\d+ (.+?) \[");
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -50,6 +62,8 @@ namespace ThermoRawFileParser.Writer
         {
             ParseInput = parseInput;
             precursorCache = new LimitedSizeDictionary<int, MZArray>(10);
+            _precursorScanNumbers[""] = -1;
+            _precursorTree[-1] = new PrecursorInfo();
         }
 
         /// <inheritdoc />
@@ -251,6 +265,68 @@ namespace ThermoRawFileParser.Writer
             }
 
             return precursorIntensity;
+        }
+
+        private protected int GetParentFromScanString(string scanString)
+        {
+            var parts = Regex.Split(scanString, " ");
+
+            //find the position of the first (from the end) precursor with a different mass 
+            //to account for possible supplementary activations written in the filter
+            var lastIonMass = parts.Last().Split('@').First();
+            int last = parts.Length;
+            while (last > 0 &&
+                   parts[last - 1].Split('@').First() == lastIonMass)
+            {
+                last--;
+            }
+
+            string parentFilter = String.Join(" ", parts.Take(last));
+            if (_precursorScanNumbers.ContainsKey(parentFilter))
+            {
+                return _precursorScanNumbers[parentFilter];
+            }
+
+            return -2; //unsuccessful parsing
+        }
+
+        private protected int FindLastReaction(IScanEvent scanEvent, int msLevel)
+        {
+            int lastReactionIndex = msLevel - 2;
+
+            //iteratively trying find the last available index for reaction
+            while (true)
+            {
+                try
+                {
+                    scanEvent.GetReaction(lastReactionIndex + 1);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    //stop trying
+                    break;
+                }
+
+                lastReactionIndex++;
+            }
+
+            //supplemental activation flag is on -> one of the levels (not necissirily the last one) used supplemental activation
+            //check last two activations
+            if (scanEvent.SupplementalActivation == TriState.On)
+            {
+                var lastActivation = scanEvent.GetReaction(lastReactionIndex).ActivationType;
+                var beforeLastActivation = scanEvent.GetReaction(lastReactionIndex - 1).ActivationType;
+
+                if ((beforeLastActivation == ActivationType.ElectronTransferDissociation || beforeLastActivation == ActivationType.ElectronCaptureDissociation) &&
+                    (lastActivation == ActivationType.CollisionInducedDissociation || lastActivation == ActivationType.HigherEnergyCollisionalDissociation))
+                    return lastReactionIndex - 1; //ETD or ECD followed by HCD or CID -> supplemental activation in the last level (move the last reaction one step back)
+                else
+                    return lastReactionIndex;
+            }
+            else //just use the last one
+            {
+                return lastReactionIndex;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR implements writer for mzParquet (v 0.2) similar to other formats.
Difference to PR #188:
- Precursor resolving is similar to mzML and MGF
- Support for centroiding and profile output
- Support for MS levels
- Reporting progress
- GZip disabled if parquet is used
- Minor changes in the parquet schema (`int` is used for precursor_scan instead of `uint`; 0 - MS1 scan, negative value - no precursor)

Closes #188