### PR TITLE
Fix typo: occured -> occurred (x6)

### DIFF
--- a/MainClass.cs
+++ b/MainClass.cs
@@ -310,7 +310,7 @@ namespace ThermoRawFileParser
                 }
                 else
                 {
-                    Log.Error("An unexpected error occured:");
+                    Log.Error("An unexpected error occurred:");
                     Log.Error(ex.ToString());
                 }
             }
@@ -473,7 +473,7 @@ namespace ThermoRawFileParser
                 }
                 else
                 {
-                    Log.Error("An unexpected error occured:");
+                    Log.Error("An unexpected error occurred:");
                     Log.Error(ex.ToString());
                 }
             }
@@ -853,8 +853,8 @@ namespace ThermoRawFileParser
             catch (Amazon.S3.AmazonS3Exception ex)
             {
                 Log.Error(!ex.Message.IsNullOrEmpty()
-                    ? "An Amazon S3 exception occured: " + ex.Message
-                    : "An Amazon S3 exception occured: " + ex);
+                    ? "An Amazon S3 exception occurred: " + ex.Message
+                    : "An Amazon S3 exception occurred: " + ex);
             }
             catch (Exception ex)
             {
@@ -864,7 +864,7 @@ namespace ThermoRawFileParser
                 }
                 else
                 {
-                    Log.Error("An unexpected error occured:");
+                    Log.Error("An unexpected error occurred:");
                     Log.Error(ex.ToString());
                 }
             }

--- a/RawFileParser.cs
+++ b/RawFileParser.cs
@@ -82,7 +82,7 @@ namespace ThermoRawFileParser
                 }
                 else
                 {
-                    Log.Error("An unexpected error occured (see below)");
+                    Log.Error("An unexpected error occurred (see below)");
                     Log.Error(ex.ToString());
                     parseInput.NewError();
                 }


### PR DESCRIPTION
Fixes 6 occurrences of `occured` → `occurred` typo in C# error log messages:

- MainClass.cs (4x): `An unexpected error occured` → `An unexpected error occurred`
- MainClass.cs (2x): `An Amazon S3 exception occured` → `An Amazon S3 exception occurred`
- RawFileParser.cs (2x): `An unexpected error occured` → `An unexpected error occurred`

All are user-facing error log messages in exception handlers.